### PR TITLE
Fix tuto and pdf path

### DIFF
--- a/Docs/pages/tuto-2BoitesAvecRecouvrement.rst
+++ b/Docs/pages/tuto-2BoitesAvecRecouvrement.rst
@@ -76,11 +76,8 @@ Il est alors possible de :ref:`sauvegarder<exporter-script>` l'ensemble des comm
 
 .. code-block:: python
 
-  #!/ccc/products/nec/bin/maillage_python
-  # -*- coding: iso-8859-15 -*-
+  # -*- coding: utf-8 -*-
   import sys
-  sys.path.append("/ccc/products/nec/share/packages")
-  import maillage
   import pyMagix3D as Mgx3D
   ctx = Mgx3D.getStdContext()
 
@@ -95,7 +92,7 @@ Il est alors possible de :ref:`sauvegarder<exporter-script>` l'ensemble des comm
   # Création du maillage pour tous les blocs
   ctx.getMeshManager().newAllBlocksMesh()
   # Sauvegarde du maillage (mli)
-  ctx.getMeshManager().writeMli("deuxBoitesRP.mli")
+  ctx.getMeshManager().writeMli("deuxBoitesRP.mli2")
 
 .. |deuxBoitesRPFaces1| image:: ../images/DeuxBoitesRP_faces1.jpeg
   :width: 450px

--- a/Docs/pages/tuto-2BoitesConformes.rst
+++ b/Docs/pages/tuto-2BoitesConformes.rst
@@ -144,7 +144,7 @@ Le panneau *Commandes python* fait alors apparaître les commandes suivantes :
 .. code-block:: python
 
   ctx.getMeshManager().newAllBlocksMesh()
-  ctx.getMeshManager().writeMli("deuxBoites.mli")
+  ctx.getMeshManager().writeMli("deuxBoites.mli2")
 
 .. _sauvegarde-cas-conforme:
 
@@ -156,11 +156,8 @@ Le fichier obtenu sera équivalent à ceci :
 
 .. code-block:: python
 
-  #!/ccc/products/nec/bin/maillage_python
-  # -*- coding: iso-8859-15 -*-
+  # -*- coding: utf-8 -*-
   import sys
-  sys.path.append("/ccc/products/nec/share/packages")
-  import maillage
   import pyMagix3D as Mgx3D
   ctx = Mgx3D.getStdContext()
 
@@ -175,6 +172,6 @@ Le fichier obtenu sera équivalent à ceci :
   # Création du maillage pour tous les blocs
   ctx.getMeshManager().newAllBlocksMesh()
   # Sauvegarde du maillage (mli)
-  ctx.getMeshManager().writeMli("deuxBoites.mli")
+  ctx.getMeshManager().writeMli("deuxBoites.mli2")
 
 .. include:: substitution-images.rst

--- a/Docs/pages/tuto-3DRevolution.rst
+++ b/Docs/pages/tuto-3DRevolution.rst
@@ -113,16 +113,13 @@ Il est alors possible de :ref:`sauvegarder<exporter-script>` l'ensemble des comm
 
 .. code-block:: python
 
-  #!/ccc/products/nec/bin/maillage_python
-  # -*- coding: iso-8859-15 -*-
+  # -*- coding: utf-8 -*-
   import sys
-  sys.path.append("/ccc/products/nec/share/packages")
-  import maillage
   import pyMagix3D as Mgx3D
   ctx = Mgx3D.getStdContext()
 
   # Import Mdl (géom et topo)
-  ctx.getTopoManager().importMDL("/cea/BS/home/magix3d/magix3d/tutorial/cylindreOr.mdl",False)
+  ctx.getTopoManager().importMDL("cylindreOr.mdl",False)
   # Découpage de toutes les faces 2D structurées
   ctx.getTopoManager().splitAllFaces ("Ar0002", .5, .5)
   # Construction Topo et Geom 3D avec o-grid par révolution
@@ -130,7 +127,7 @@ Il est alors possible de :ref:`sauvegarder<exporter-script>` l'ensemble des comm
   # Création du maillage pour tous les blocs
   ctx.getMeshManager().newAllBlocksMesh()
   # Sauvegarde du maillage (mli)
-  ctx.getMeshManager().writeMli("cylindreOr.mli")
+  ctx.getMeshManager().writeMli("cylindreOr.mli2")
 
 .. note::
   Pour aller plus loin avec votre cas 2D, il est nécessaire de voir les recommandations générales pour le passage de votre cas 2D au modèle bloc structuré en 3D. 

--- a/Docs/resources/cylindreOreille.py
+++ b/Docs/resources/cylindreOreille.py
@@ -5,8 +5,6 @@
 # fonctionne avec la version 1.14.2 le 11/06/2019
 
 import sys
-sys.path.append("/ccc/products/nec/share/packages")
-import maillage
 import pyMagix3D as Mgx3D
 ctx = Mgx3D.getStdContext()
 
@@ -142,4 +140,4 @@ ctx.getTopoManager().replaceTransfiniteByDirectionalMeshMethodAsPossible()
 # Création du maillage pour tous les blocs
 ctx.getMeshManager().newAllBlocksMesh()
 # Sauvegarde du maillage (mli)
-ctx.getMeshManager().writeMli("cylindreOreille.mli")
+ctx.getMeshManager().writeMli("cylindreOreille.mli2")

--- a/src/Magix3D/cmake/Magix3D.in
+++ b/src/Magix3D/cmake/Magix3D.in
@@ -31,7 +31,7 @@ HELP_URL="-helpURL $ROOT_DIR/share/doc/@CMAKE_PROJECT_NAME@/sphinx"
 WIKI_URL="-wikiURL @URL_WIKI@"
 QUALIF_URL="-qualifURL @URL_QUALIF@"
 
-USER_MANUAL="-userManual $ROOT_DIR/share/doc/@CMAKE_PROJECT_NAME@/sphinx/magix3d.pdf"
+USER_MANUAL="-userManual $ROOT_DIR/share/doc/@CMAKE_PROJECT_NAME@/sphinx/pdf/magix3d.pdf"
 DOC_VIEWER="-docViewer firefox"
 DEFAULT_CONFIG="-defaultConfig $ROOT_DIR/etc/magix3d.xml"
 CONFIG_PATCHS="-userConfigPatchs $ROOT_DIR/etc/magix3d_patchs.xml"


### PR DESCRIPTION
- added missing directory `pdf` in the pdf manual path in the launcher
- cleaned up the tutorials now that `mli` is deprecated in favor of `mli2`and removing obsolete maillage python module