### PR TITLE
Issue #111 fix. The OCC precision of geometric entities is only displ…

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -59,6 +59,10 @@ endif (TRITON)
 message(MGX OPTIONS ${MAGIX3D_OPTIONS})
 set (MANDATORY_CXX_OPTIONS ${MANDATORY_VTK_OPTIONS} ${MANDATORY_MULTITHREADING_OPTIONS} ${MAGIX3D_OPTIONS})
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+	add_compile_definitions (_DEBUG)
+endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
+
 # Edition des liens :
 # A l'installation les RPATHS utilisés seront ceux spécifiés ci-dessous (liste
 # de répertoires séparés par des ;) :

--- a/src/Core/Geom/Curve.cpp
+++ b/src/Core/Geom/Curve.cpp
@@ -1511,14 +1511,17 @@ Utils::SerializedRepresentation* Curve::getDescription (bool alsoComputed) const
 	        Utils::SerializedRepresentation::Property ("Longueur", volStr.ascii()) );
 	}
 
-    // précision OpenCascade
 	std::vector<GeomRepresentation*> reps = getComputationalProperties();
+	
+#ifdef _DEBUG		// Issue#111
+    // précision OpenCascade
 	for (uint i=0; i<reps.size(); i++){
 	    TkUtil::UTF8String precStr (TkUtil::Charset::UTF_8);
 		precStr << reps[i]->getPrecision();
 	    propertyGeomDescription.addProperty (
 	    	        Utils::SerializedRepresentation::Property ("Précision", precStr.ascii()) );
 	}
+#endif	// _DEBUG
 
 	// recherche des infos pour le cas facétisé
 	bool isFaceted = false;

--- a/src/Core/Geom/Surface_Geom.cpp
+++ b/src/Core/Geom/Surface_Geom.cpp
@@ -760,14 +760,17 @@ Utils::SerializedRepresentation* Surface::getDescription (bool alsoComputed) con
 	        Utils::SerializedRepresentation::Property ("Aire", volStr.ascii()) );
 	}
 
-    // précision OpenCascade ou autre
 	std::vector<GeomRepresentation*> reps = getComputationalProperties();
+	
+#ifdef _DEBUG		// Issue#111
+    // précision OpenCascade ou autre
 	for (uint i=0; i<reps.size(); i++){
 		TkUtil::UTF8String	precStr (TkUtil::Charset::UTF_8);
 		precStr << reps[i]->getPrecision();
 	    propertyGeomDescription.addProperty (
 	    	        Utils::SerializedRepresentation::Property ("Précision", precStr.ascii()) );
 	}
+#endif	// _DEBUG
 
 	// recherche des infos pour le cas facétisé
 	bool isFaceted = false;
@@ -779,7 +782,6 @@ Utils::SerializedRepresentation* Surface::getDescription (bool alsoComputed) con
 			nbFaces = fs->getNbFaces();
 		}
 	}
-
 
     // on ajoute des infos du style: c'est un plan
 	TkUtil::UTF8String	typeStr (TkUtil::Charset::UTF_8);

--- a/src/Core/Geom/Vertex_Geom.cpp
+++ b/src/Core/Geom/Vertex_Geom.cpp
@@ -109,12 +109,14 @@ Mgx3D::Utils::SerializedRepresentation* Vertex::getDescription (bool alsoCompute
 											"Propriété géométrique", coordsProp.getValue ( ));
 	propertyGeomDescription.addProperty (coordsProp);
 
+#ifdef _DEBUG		// Issue#111
     // précision OpenCascade ou autre
 	TkUtil::UTF8String	precStr (TkUtil::Charset::UTF_8);
     precStr<<getComputationalProperty()->getPrecision();
 
     propertyGeomDescription.addProperty (
     	        Utils::SerializedRepresentation::Property ("Précision", precStr.ascii()) );
+#endif	// _DEBUG
 
     bool isFaceted = false;
     FacetedVertex* fv = dynamic_cast<FacetedVertex*>(getComputationalProperty());

--- a/src/Core/Topo/Face.cpp
+++ b/src/Core/Topo/Face.cpp
@@ -1021,7 +1021,8 @@ getNodes(Vertex* sommet1, Vertex* sommet2, Vertex* sommet3, Vertex* sommet4,
 #ifdef _DEBUG
         uint nbError = 0;
         for (int i=0; i<nbNoeudsI*nbNoeudsJ; i++)
-            if (vectNd[i].getID() == gmds::NullID) {
+//            if (vectNd[i].getID() == gmds::NullID) {
+            if (vectNd[i].id() == gmds::NullID) {	// CP
                 std::cout<<"vectNd["<<i<<"] non renseigné !\n";
                 nbError++;
             }


### PR DESCRIPTION
…ayed in the individual properties of the selection in debug mode  similar to what is done in GeomEntity::getDescription(). Enabling the _DEBUG compilation directive when CMAKE_BUILD_TYPE is Debug.