### PR TITLE
Optimization of user-initiated display operations (show/hide checkbox…

### DIFF
--- a/src/QtComponents/QtEntitiesPanel.cpp
+++ b/src/QtComponents/QtEntitiesPanel.cpp
@@ -241,11 +241,9 @@ void QtEntitiesGroupTreeWidgetItem::stateChange (int col)
 
 			// Verrouiller les opérations d'affichage (optimisation) :
 			CHECK_NULL_PTR_ERROR (_panel)
-			Qt3DGraphicalWidget*	graphicalWidget	=
-												_panel->getGraphicalWidget ( );
+			Qt3DGraphicalWidget*	graphicalWidget	= _panel->getGraphicalWidget ( );
 			CHECK_NULL_PTR_ERROR (graphicalWidget)
-			RenderingManager::DisplayLocker	displayLocker(
-									graphicalWidget->getRenderingManager ( ));
+			RenderingManager::DisplayLocker	displayLocker (graphicalWidget->getRenderingManager ( ));
 			vector<Entity*>			entities;
 			unsigned long			mask	= 0;
 			const bool	checked	= Qt::Checked == currentState ? true : false;
@@ -255,25 +253,18 @@ void QtEntitiesGroupTreeWidgetItem::stateChange (int col)
 				CHECK_NULL_PTR_ERROR (item)
 				bool	changed	= !(item->checkState (0) == currentState);
 				item->setCheckState (0, currentState);
-				QtEntityTreeWidgetItem*	entityItem	=
-					dynamic_cast<QtEntityTreeWidgetItem*>(item);
+				QtEntityTreeWidgetItem*	entityItem	= dynamic_cast<QtEntityTreeWidgetItem*>(item);
 				CHECK_NULL_PTR_ERROR (entityItem)
 				if (false == _panel->groupEntitiesDisplayModifications ( ))
-					graphicalWidget->getRenderingManager (
-													).displayRepresentation (
-							*(entityItem->getEntity ( )), checked,
-							entityItem->getRepresentationMask ( ));
+					graphicalWidget->getRenderingManager ( ).displayRepresentation (*(entityItem->getEntity ( )), checked, entityItem->getRepresentationMask ( ), false);
 				else if (true == changed)
 				{
 					entities.push_back (entityItem->getEntity ( ));
 					mask	= entityItem->getRepresentationMask ( );
 				}	// else if (true == changed)
 			}	// for (int i = 0; i < childCount ( ); i++)
-			if ((true == _panel->groupEntitiesDisplayModifications ( )) &&
-			    (0 != entities.size ( )))
-				graphicalWidget->getRenderingManager (
-						).displayRepresentations (entities, currentState, mask,
-						                          getEntitiesType ( ));
+			if ((true == _panel->groupEntitiesDisplayModifications ( )) && (0 != entities.size ( )))
+				graphicalWidget->getRenderingManager ( ).displayRepresentations (entities, currentState, mask, getEntitiesType ( ));
 		}	// case 0
 		break;
 		case	1	:	// Mode d'affichage 3D
@@ -2197,9 +2188,7 @@ void QtEntitiesPanel::itemStateChange (QTreeWidgetItem*item , bool updateParent)
 		return;
 
 	const bool	checked	= Qt::Checked == item->checkState (0) ? true : false;
-	getGraphicalWidget ( )->getRenderingManager ( ).displayRepresentation (
-							*(entityItem->getEntity ( )), checked,
-							entityItem->getRepresentationMask ( ));
+	getGraphicalWidget ( )->getRenderingManager ( ).displayRepresentation (*(entityItem->getEntity ( )), checked, entityItem->getRepresentationMask ( ), true);
 
 	if (true == updateParent)
 	{
@@ -2232,12 +2221,9 @@ void QtEntitiesPanel::itemsStateChange (const vector<QTreeWidgetItem*>& list , b
 	CHECK_NULL_PTR_ERROR (getGraphicalWidget ( ))
 	QTreeWidgetItem*	parent	= list [0]->parent ( );
 
-	unique_ptr<RenderingManager::DisplayLocker>	displayLocker (
-		new RenderingManager::DisplayLocker (
-							getGraphicalWidget ( )->getRenderingManager ( )));
+	unique_ptr<RenderingManager::DisplayLocker>	displayLocker (new RenderingManager::DisplayLocker (getGraphicalWidget ( )->getRenderingManager ( )));
 	size_t	i	= 0;
-	for (vector<QTreeWidgetItem*>::const_iterator it = list.begin ( );
-	     list.end ( ) != it; it++, i++)
+	for (vector<QTreeWidgetItem*>::const_iterator it = list.begin ( ); list.end ( ) != it; it++, i++)
 	{
 
 		CHECK_NULL_PTR_ERROR (*it)
@@ -2246,20 +2232,15 @@ void QtEntitiesPanel::itemsStateChange (const vector<QTreeWidgetItem*>& list , b
 			continue;
 
 		const bool	checked	= Qt::Checked == (*it)->checkState (0) ? true:false;
-		getGraphicalWidget ( )->getRenderingManager ( ).displayRepresentation (
-							*(entityItem->getEntity ( )), checked,
-							entityItem->getRepresentationMask ( ));
+		getGraphicalWidget ( )->getRenderingManager ( ).displayRepresentation (*(entityItem->getEntity ( )), checked, entityItem->getRepresentationMask ( ), true);
 		if (0 == i % Resources::instance ( )._updateRefreshRate.getValue ( ))
 		{	// On fait un render tous les x entités.
 
-			// On veut unlock avant lock => en 2 temps (reset (0) puis
-			// reset (new DisplayLocker (...)).
-			// Si directement reset (new DisplayLocker (...))  on a
-			// new DisplayLocker (...)
+			// On veut unlock avant lock => en 2 temps (reset (0) puis reset (new DisplayLocker (...)).
+			// Si directement reset (new DisplayLocker (...))  on a new DisplayLocker (...)
 			// puis delete de l'ancien DisplayLocker => unlock en dernier ...
 			displayLocker.reset (0);
-			displayLocker.reset (new RenderingManager::DisplayLocker (
-							getGraphicalWidget ( )->getRenderingManager ( )));
+			displayLocker.reset (new RenderingManager::DisplayLocker (getGraphicalWidget ( )->getRenderingManager ( )));
 			// Eventuelle actualisation IHM :
 			if (true == QApplication::hasPendingEvents ( ))
 //				QApplication::processEvents (QEventLoop::AllEvents, 5000);

--- a/src/QtComponents/QtMgx3DMainWindow.cpp
+++ b/src/QtComponents/QtMgx3DMainWindow.cpp
@@ -4399,7 +4399,7 @@ const SelectionManagerIfc& QtMgx3DMainWindow::getSelectionManager ( ) const
 										te->getDisplayProperties().setDisplayed(!displayed);
 										// Puis on réaffecte => forcera l'actualisation de la représentation :
 										if (0 != rer)
-											getGraphicalWidget().getRenderingManager( ).displayRepresentation(*te, displayed, rer->getRepresentationMask());
+											getGraphicalWidget().getRenderingManager( ).displayRepresentation(*te, displayed, rer->getRepresentationMask(), true);
 									}
 
 						if (0 == (i % Resources::instance()._updateRefreshRate.getValue()))

--- a/src/QtComponents/protected/QtComponents/RenderingManager.h
+++ b/src/QtComponents/protected/QtComponents/RenderingManager.h
@@ -127,10 +127,11 @@ class RenderingManager : public Utils::SelectionManagerObserver
 	 * \param		Entité à représenter
 	 * \param		<I>true</I> s'il faut représenter l'entité, <I>false</I> dans le cas contraire.
 	 * \param		Masque d'affichage de l'entité (cf.  <I>GraphicalEntityRepresentation::CURVES</I> et autres).
+	 * \param		<I>true</I> s'il faut forcer le rendu dans la fenêtre graphique.
 	 * \see			hasDisplayedRepresentation
 	 * \see			isDisplayed
 	 */
-	virtual void displayRepresentation(Mgx3D::Utils::Entity &entity, bool show, unsigned long mask);
+	virtual void displayRepresentation(Mgx3D::Utils::Entity &entity, bool show, unsigned long mask, bool forceRender);
 
 	/**
 	 * Affiche ou masque, selon la valeur de <I>show</I>, les représentations des entités transmises en argument.
@@ -141,10 +142,7 @@ class RenderingManager : public Utils::SelectionManagerObserver
 	 * \see			hasDisplayedRepresentation
 	 * \see			isDisplayed
 	 */
-	virtual void displayRepresentations(
-			const std::vector<Mgx3D::Utils::Entity *> &entities,
-			bool show, unsigned long mask,
-			Mgx3D::Utils::DisplayRepresentation::display_type type);
+	virtual void displayRepresentations(const std::vector<Mgx3D::Utils::Entity *> &entities, bool show, unsigned long mask, Mgx3D::Utils::DisplayRepresentation::display_type type);
 
 	/**
 	 * Affiche ou masque, selon la valeur de <I>show</I>, les représentations des entités des groupes transmis en argument.
@@ -1225,14 +1223,12 @@ class RenderingManager : public Utils::SelectionManagerObserver
 	 * Affiche ou détruit la représentation 3D transmise en argument.
 	 * A spécialiser dans les classes dérivées selon l'API 3D utilisée.
 	 * \param		Représentation à afficher ou détruire.
-	 * \param		<I>true</I> s'il faut afficher la représentation,
-	 *				<I>false</I> s'il faut la détruire.
-	 * \param		<I>true</I> s'il faut forcer l'actualisation de la
-	 *				représentation graphique.
-	 * \param		Masque d'affichage de l'entité (cf. 
-	 *				<I>GraphicalEntityRepresentation::CURVES</I> et autres.
+	 * \param		<I>true</I> s'il faut afficher la représentation, <I>false</I> s'il faut la détruire.
+	 * \param		<I>true</I> s'il faut forcer l'actualisation de la représentation graphique.
+	 * \param		<I>true</I> s'il faut forcer l'opération de rendu dans la fenêtre graphique.
+	 * \param		Masque d'affichage de l'entité (cf. <I>GraphicalEntityRepresentation::CURVES</I> et autres.
 	 */
-	virtual void displayRepresentation (Utils::GraphicalEntityRepresentation& representation, bool show, bool forceUpdate, unsigned long mask);
+	virtual void displayRepresentation (Utils::GraphicalEntityRepresentation& representation, bool show, bool forceUpdate, bool forceRender, unsigned long mask);
 
 	/**
 	 * Affiche/masque les groupes d'entités transmis en arguments.

--- a/src/QtVtkComponents/VTKRenderingManager.cpp
+++ b/src/QtVtkComponents/VTKRenderingManager.cpp
@@ -2328,20 +2328,19 @@ Utils::GraphicalEntityRepresentation* VTKRenderingManager::createRepresentation 
 }	// VTKRenderingManager::createRepresentation
 
 
-void VTKRenderingManager::displayRepresentation (
-	Utils::GraphicalEntityRepresentation& representation, bool show,
-	bool forceUpdate, unsigned long mask)
+void VTKRenderingManager::displayRepresentation (Utils::GraphicalEntityRepresentation& representation, bool show, bool forceUpdate, bool doRender, unsigned long mask)
 {
 	VTKEntityRepresentation*	vtkRep	= dynamic_cast<VTKEntityRepresentation*>(&representation);
 	CHECK_NULL_PTR_ERROR (vtkRep);
 	if (true == show)
 	{
-		vtkRep->setRenderingManager (this);	// Nécessaire pour le code de projetections, affichage 3D/CELL_VALUES
+		vtkRep->setRenderingManager (this);	// Nécessaire pour le code de projections, affichage 3D/CELL_VALUES
 		vtkRep->updateRepresentation (mask, forceUpdate);
 	}	// if (true == show)
 	vtkRep->show (*this, show);
 
-	forceRender ( );
+	if (true == doRender)
+		forceRender ( );
 }	// VTKRenderingManager::displayRepresentation
 
 

--- a/src/QtVtkComponents/protected/QtVtkComponents/VTKRenderingManager.h
+++ b/src/QtVtkComponents/protected/QtVtkComponents/VTKRenderingManager.h
@@ -919,16 +919,12 @@ class VTKRenderingManager : public QtComponents::RenderingManager
 	/**
 	 * Affiche ou détruit la représentation 3D transmise en argument.
 	 * \param		Représentation à afficher ou détruire.
-	 * \param		<I>true</I> s'il faut afficher la représentation,
-	 *				<I>false</I> s'il faut la détruire.
-	 * \param		<I>true</I> s'il faut forcer l'actualisation de la
-	 *				représentation graphique.
-	 * \param		Masque d'affichage de l'entité (cf. 
-	 *				<I>GraphicalEntityRepresentation::CURVES</I> et autres.
+	 * \param		<I>true</I> s'il faut afficher la représentation, <I>false</I> s'il faut la détruire.
+	 * \param		<I>true</I> s'il faut forcer l'actualisation de la représentation graphique.
+	 * \param		<I>true</I> s'il faut forcer l'opération de rendu dans la fenêtre graphique.
+	 * \param		Masque d'affichage de l'entité (cf. <I>GraphicalEntityRepresentation::CURVES</I> et autres.
 	 */
-	virtual void displayRepresentation (
-				Utils::GraphicalEntityRepresentation& representation,
-				bool show, bool forceUpdate, unsigned long mask);
+	virtual void displayRepresentation (Utils::GraphicalEntityRepresentation& representation, bool show, bool forceUpdate, bool forceRender, unsigned long mask);
 
 	/**
 	 * Classe actualisant la vue graphique lors de certains évènements


### PR DESCRIPTION
…es, selections, ...) by processing them in batches. The batch size is defined by the Magix3D.gui.theatre.updateRefreshRate user preference which is 100 by default, to be adjusted according to the user and the workstation.