### PR TITLE
issue #86. lifting surface area limitation for using GeomAPI_ProjectPointOnSurf

### DIFF
--- a/src/Core/Geom/OCCGeomRepresentation.cpp
+++ b/src/Core/Geom/OCCGeomRepresentation.cpp
@@ -1791,11 +1791,12 @@ void OCCGeomRepresentation::projectPointOn( Utils::Math::Point& P)
 	{
 		gp_Pnt pnt(P.getX(),P.getY(),P.getZ());
 
-        // issue#86 : dans le cas des surfaces, si la surface est toute petite,
+        // issue#86 : dans le cas des surfaces
         // il faut projeter avec GeomAPI_ProjectPointOnSurf au lieu de
-        // BRepExtrema_DistShapeShape pour éviter les imprécisions numériques.
+        // BRepExtrema_DistShapeShape pour éviter que le point ne se
+        // retrouve au bord de la surface
         bool is_done = false;
-        if (m_shape.ShapeType()==TopAbs_FACE && computeSurfaceArea()<getPrecision()) {
+        if (m_shape.ShapeType()==TopAbs_FACE) {
             // Initialisation du projecteur
             TopoDS_Face face = TopoDS::Face(m_shape);
             Handle(Geom_Surface) surface = BRep_Tool::Surface(face);


### PR DESCRIPTION
Complements https://github.com/LIHPC-Computational-Geometry/magix3d/pull/36

Using `GeomAPI_ProjectPointOnSurf` when projecting a node onto a surface was a good idea, but we should generalize it instead of calling it only for small surfaces.

First tests show :
- the original issue -- projected nodes ending up on one of the curves delimiting the surface -- was not limited to small surfaces;
- the cost of computing the surface's area for each node is too high
The following script takes 700s vs 7s when computing the surface area and without, and 210s when using `BRepExtrema_DistShapeShape`
```python
# Création d'une boite avec une topologie
ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 1000, 1000, 1000)
# Création du maillage pour des faces
ctx.getMeshManager().newFacesMesh ( ["Fa0000", "Fa0001", "Fa0002", "Fa0003", "Fa0004", "Fa0005"] )
```

