### PR TITLE
issue #159. smooth and perturbation premesh fix

### DIFF
--- a/src/Core/Mesh/CommandNewBlocksMesh.cpp
+++ b/src/Core/Mesh/CommandNewBlocksMesh.cpp
@@ -102,7 +102,23 @@ internalExecute()
    TkUtil::Timer timer(false);
 #endif
 
+    // delete the premesh of the edges to accommodate for possible smooth/pert modifications
+    // applied to adjacent surfaces
+    {
+        std::set<Topo::CoEdge *> set_coedges;
+        for (auto b: m_blocks) {
+            std::vector<Topo::CoEdge *> coedges;
+            b->getCoEdges(coedges);
 
+            for (auto ce: coedges) {
+                set_coedges.insert(ce);
+            }
+        }
+        for (auto ce: set_coedges) {
+            ce->clearPoints();
+            ce->getMeshingData()->setPreMeshed(false);
+        }
+    }
 
     // maille et modifie le maillage pour les modifications 2D, s'il y en a
     // cette étape est à effectuer avant le maillage de toutes les arêtes car le lissage

--- a/src/Core/Mesh/CommandNewFacesMesh.cpp
+++ b/src/Core/Mesh/CommandNewFacesMesh.cpp
@@ -101,6 +101,24 @@ internalExecute()
             iter != m_faces.end(); ++iter)
         (*iter)->check();
 
+    // delete the premesh of the edges to accommodate for possible smooth/pert modifications
+    // applied to adjacent surfaces
+    {
+        std::set<Topo::CoEdge *> set_coedges;
+        for (auto cf: list_cofaces) {
+            std::vector<Topo::CoEdge *> coedges;
+            cf->getCoEdges(coedges);
+
+            for (auto ce: coedges) {
+                set_coedges.insert(ce);
+            }
+        }
+        for (auto ce: set_coedges) {
+            ce->clearPoints();
+            ce->getMeshingData()->setPreMeshed(false);
+        }
+    }
+
     // maille et modifie le maillage pour les modifications 2D, s'il y en a
     setStepProgression (1.);
 	setStep (++step, "Lissage et perturbation des surfaces", 0.);

--- a/test_link/test_perturbation.py
+++ b/test_link/test_perturbation.py
@@ -1,0 +1,42 @@
+import pyMagix3D as Mgx3D
+import pytest
+
+def test_perturbation(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+
+    def pert(x,y,z):
+        if(z>=0.4):
+            z = 0.4
+        return [x,y,z]
+
+    ctx.getTopoManager().newSphereWithTopo (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Portion.ENTIER, True, .5, 10, 10)
+    ctx.getGeomManager().addToGroup (["Surf0000"], 2, "bord")
+    ctx.getGroupManager().addCartesianPerturbation("bord", pert)
+    ctx.getMeshManager().newAllBlocksMesh()
+    out, err = capfd.readouterr()
+    assert("Des hexaédres semblent inversés dans le maillage structuré" not in err)
+
+def test_perturbation_surf(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    def pert(x,y,z):
+        if(z>=0.4):
+            z = 0.4
+        return [x,y,z]
+
+    ctx.getTopoManager().newSphereWithTopo (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Portion.ENTIER, True, .5, 10, 10)
+    ctx.getGeomManager().addToGroup (["Surf0000"], 2, "bord")
+    ctx.getGroupManager().addCartesianPerturbation("bord", pert)
+    ctx.getTopoManager().addToGroup (["Fa0014"], 2, "aaa")
+    # we mesh one of the diagonal faces to force the premesh generation
+    # of its edges
+    ctx.getMeshManager().newFacesMesh ( ["Fa0014"] )
+    ctx.undo()
+    # we mesh the surface on which the perturbation is applied to
+    ctx.getMeshManager().newFacesMesh ( ["Fa0010", "Fa0016", "Fa0022", "Fa0028", "Fa0034", "Fa0040"] )
+    # we mesh again the diagonal face : if edge Ar0058's premesh is used
+    # we have bad quality elements
+    ctx.getMeshManager().newFacesMesh ( ["Fa0014"] )
+    out, err = capfd.readouterr()
+    assert("Des polygones semblent retournés" not in out)


### PR DESCRIPTION
When meshing and undoing the mesh or when displaying the edges projected onto their associated geometry, a premesh of those edges is created and kept. It will be used for subsequent meshing of those edges.

When meshing a surface on which a modification (smoothing or pertubation) is applied, the adjacent edges -- that have a topo vertex on the surface but are not associated to the surface -- have their premesh not matching the new position of their vertex, resulting in a not so good mesh with potentially inverted elements.

The code already ordered meshing starting with the surfaces with modifications, but left the existing premeshes.
This dev forces the re-generation of the premeshes so that they are up-to-date when meshing an entity.