### PR TITLE
Highlighting and selection fix

### DIFF
--- a/src/Core/protected/Internal/EntitiesHelper.h
+++ b/src/Core/protected/Internal/EntitiesHelper.h
@@ -14,6 +14,7 @@
 
 #include <TkUtil/InternalError.h>
 
+#include <algorithm>
 #include <vector>
 #include <string>
 
@@ -174,6 +175,23 @@ template < typename E > inline std::vector< Mgx3D::Utils::Entity* > entitiesFrom
 
 	return entities;
 }	// entitiesFromTypedEntities
+
+/**
+ * \return		La différence entre les 2 listes d'entités reçues en premiers arguments.
+ * \param		before et after représentent la même liste d'entités avant et après un évènement, par exemple l'exécution d'une commande
+ * \param		En sortie added recevra les entités présentes dans after mais pas dans before
+ * \param		En sortie removed recevra les entités présentes dans before mais pas dans after
+ */
+template < typename E > inline void difference (
+			const std::vector< E* >& before, const std::vector< E* >& after, std::vector< E* >& added, std::vector< E* >& removed)
+{
+	for (typename std::vector< E* >::const_iterator ite = after.begin ( ); after.end ( ) != ite; ite++)
+		if (before.end ( ) == std::find (before.begin ( ), before.end ( ), *ite))
+			added.push_back (*ite);
+	for (typename std::vector< E* >::const_iterator ite = before.begin ( ); before.end ( ) != ite; ite++)
+		if (after.end ( ) == std::find (after.begin ( ), after.end ( ), *ite))
+			removed.push_back (*ite);
+}	// difference
 
 
 /*----------------------------------------------------------------------------*/

--- a/src/QtComponents/EntitySeizureManager.cpp
+++ b/src/QtComponents/EntitySeizureManager.cpp
@@ -8,6 +8,7 @@
 
 #include "QtComponents/EntitySeizureManager.h"
 #include "QtComponents/QtMgx3DMainWindow.h"
+#include "Internal/EntitiesHelper.h"
 
 #include <Utils/Common.h>
 
@@ -239,9 +240,11 @@ void EntitySeizureManager::setInteractiveMode (bool enable)
 			// On ajoute au gestionnaire de sélection la ou les entités déjà
 			// sélectionnées :
 			vector<Entity*>	entities	= getSelectedEntities ( );
-			_seizuredEntities.clear ( );
-			if (0 != entities.size ( ))
-				getSelectionManager ( )->addToSelection (entities);
+			vector<Entity*>	added, removed;
+			vector<Entity*>	currentSelection	= getSelectionManager( )->getEntities ( );
+			difference (currentSelection, entities, added, removed);
+			if (0 != added.size ( ))
+				getSelectionManager ( )->addToSelection (added);
 		}	// if (0 != getSelectionManager ( ))
 
 	}	// if (true == _interactiveMode)

--- a/src/QtComponents/QtEntityIDTextField.cpp
+++ b/src/QtComponents/QtEntityIDTextField.cpp
@@ -48,12 +48,9 @@ QtEntityIDTextField::QtEntityIDTextField (
 	// 1er callback à exécuter : filterText, le texte est peut-être issu de
 	// copier/coller avec la console python, il faut alors enlever des ,, ', ",
 	// ...
-	connect (this, SIGNAL (editingFinished ( )), this,
-	         SLOT (filterText ( )));
-	connect (this, SIGNAL (returnPressed ( )), this,
-	         SLOT (returnPressedCallback ( )));
-	connect (this, SIGNAL (editingFinished ( )), this,
-	         SLOT (textModifiedCallback ( )));
+	connect (this, SIGNAL (editingFinished ( )), this, SLOT (filterText ( )));
+	connect (this, SIGNAL (returnPressed ( )), this, SLOT (returnPressedCallback ( )));
+	connect (this, SIGNAL (editingFinished ( )), this, SLOT (textModifiedCallback ( )));
 
 	// Le menu contextuel :
 	_addGraphicalSelectionAction	= new QAction (QString::fromUtf8 ("Ajouter la sélection"), this);
@@ -349,11 +346,9 @@ void QtEntityIDTextField::addGraphicalSelectionCallback ( )
 
 void QtEntityIDTextField::addSelectedGroupsEntitiesCallback ( )
 {
-cout << "QtEntityIDTextField::addSelectedGroupsEntitiesCallback called" << endl;
 	try
 	{
 		vector<Group::GroupEntity*>	groups	= getMainWindow ( ).getGroupsPanel ( ).getSelectedGroups ( );
-cout << "CURRENT SELECTION HAS " << groups.size ( ) << " GROUPS" << endl;
 		vector<Entity*>	keptEntities;
 		for (vector<Group::GroupEntity*>::const_iterator itg = groups.begin ( );
 		     groups.end ( ) != itg; itg++)
@@ -367,7 +362,6 @@ cout << "CURRENT SELECTION HAS " << groups.size ( ) << " GROUPS" << endl;
 
 		if (0 != keptEntities.size ( ))
 			addToSelection (keptEntities);
-cout << "KEPT ENTIES COUNT IS " << keptEntities.size ( ) << endl;
 	}
 	catch (...)
 	{
@@ -704,12 +698,6 @@ void QtEntityIDTextField::textModifiedCallback ( )
 		}	// for (vector<string>::const_iterator it = names.begin ( ); names.end ( ) != it; it++)
 
 		difference (oldSelection, newSelection, added, removed);
-/*		for (vector<Entity*>::const_iterator ite = newSelection.begin ( ); newSelection.end ( ) != ite; ite++)
-			if (previousSelection.end ( ) == std::find (previousSelection.begin ( ), previousSelection.end ( ), *ite))
-				added.push_back (*ite);
-		for (vector<Entity*>::const_iterator ite = previousSelection.begin ( ); previousSelection.end ( ) != ite; ite++)
-			if (newSelection.end ( ) == std::find (newSelection.begin ( ), newSelection.end ( ), *ite))
-				removed.push_back (*ite);*/
 		if (0 != getSelectionManager ( ))
 		{
 			if (false == removed.empty ( ))

--- a/src/QtComponents/QtMgx3DOperationsPanel.cpp
+++ b/src/QtComponents/QtMgx3DOperationsPanel.cpp
@@ -676,6 +676,8 @@ void QtMgx3DOperationPanel::applyCallback ( )
 	bool	userNotified	= false;	// CP 16/09/24 false par défaut (cas où la création de commande lève une exception => pas de commandResult)																	// CP NEW
 	BEGIN_QT_TRY_CATCH_BLOCK
 
+	highlight (false);	// CP 18/02/25 : ne pas être tenté de modifier la surbrillance d'entités détruites.
+
 	CHECK_NULL_PTR_ERROR (getMgx3DOperationAction ( ))
 	getMgx3DOperationAction ( )->executeOperation ( );
 	commandResult	= getMgx3DOperationAction ( )->getCommandResult ( );
@@ -684,7 +686,10 @@ void QtMgx3DOperationPanel::applyCallback ( )
 	if (0 != commandResult)
 	{
 		if (CommandIfc::DONE == commandResult->getStatus ( ))
+		{
+			reset ( );	// CP 18/02/25 : ne pas être tenté de modifier la surbrillance d'entités détruites.
 			hasError	= false;
+		}
 		else
 		{
 			userNotified	= commandResult->isUserNotified ( );

--- a/src/QtComponents/QtMgx3DOperationsPanel.cpp
+++ b/src/QtComponents/QtMgx3DOperationsPanel.cpp
@@ -10,6 +10,7 @@
 #include "QtComponents/QtMgx3DMainWindow.h"
 #include "QtComponents/QtMgx3DApplication.h"
 #include <QtUtil/QtErrorManagement.h>
+#include <QtUtil/QtWidgetAutoLock.h>
 #include "QtComponents/RenderedEntityRepresentation.h"
 #include "QtComponents/QtMgx3DScrollArea.h"
 #include "Topo/CoEdge.h"
@@ -1840,8 +1841,8 @@ void QtMgx3DOperationsPanel::applyCallback ( )
 
 	if (0 != _operationPanel)
 	{
-//		CHECK_NULL_PTR_ERROR (_operationPanel->getMgx3DOperationAction ( ))
-//		_operationPanel->getMgx3DOperationAction ( )->executeOperation ( );
+		QtWidgetAutoLock	lock (_operationPanel);
+		
 		_operationPanel->applyCallback ( );
 	}	// if (0 != _operationPanel)
 

--- a/src/QtComponents/QtSelectionIndividualPropertiesPanel.cpp
+++ b/src/QtComponents/QtSelectionIndividualPropertiesPanel.cpp
@@ -496,13 +496,11 @@ void QtSelectionIndividualPropertiesPanel::entitiesAddedToSelection (
 						const vector<Entity*>& entities)
 {
 	BEGIN_QT_TRY_CATCH_BLOCK
-
-		if ((0 == getSelectionManager ( )) || (false == displayProperties ( )))
+	if ((0 == getSelectionManager ( )) || (false == displayProperties ( )))
 		return;
 
 	CHECK_NULL_PTR_ERROR (_entitiesWidget)
-	if (Resources::instance ( )._maxIndividualProperties.getValue ( ) <
-															entities.size ( ))
+	if (Resources::instance ( )._maxIndividualProperties.getValue ( ) < entities.size ( ))
 	{
 		UTF8String	message (Charset::UTF_8);
 		message << "Sélection courante : " << entities.size ( ) << " entités.";


### PR DESCRIPTION
Fix and optimization in Qt Entity ID TextField::text Modified Callback for issues related to highlighting during previews. Fix in EntitySeizureManager::setInteractiveMode regarding duplicates in the selection that could appear in the selection properties.