### PR TITLE
Qt dimensions selector panel fix1

### DIFF
--- a/src/QtComponents/QtDimensionsSelectorPanel.cpp
+++ b/src/QtComponents/QtDimensionsSelectorPanel.cpp
@@ -93,17 +93,15 @@ QtDimensionsSelectorPanel::QtDimensionsSelectorPanel (
 }	// QtDimensionsSelectorPanel::QtDimensionsSelectorPanel
 
 
-QtDimensionsSelectorPanel::QtDimensionsSelectorPanel (
-											const QtDimensionsSelectorPanel&)
+QtDimensionsSelectorPanel::QtDimensionsSelectorPanel (const QtDimensionsSelectorPanel&)
 	: QWidget (0), _buttonGroup (0),
-	  _d0CheckBox (0), _d1CheckBox (0), _d2CheckBox (0), _d3CheckBox (0)
+	  _d0CheckBox (0), _d1CheckBox (0), _d2CheckBox (0), _d3CheckBox (0), _allowedDimensions (SelectionManagerIfc::NO_DIM)
 {
 	MGX_FORBIDDEN ("QtDimensionsSelectorPanel copy constructor is not allowed.");
 }	// QtDimensionsSelectorPanel::QtDimensionsSelectorPanel (const QtDimensionsSelectorPanel&)
 
 
-QtDimensionsSelectorPanel& QtDimensionsSelectorPanel::operator = (
-											const QtDimensionsSelectorPanel&)
+QtDimensionsSelectorPanel& QtDimensionsSelectorPanel::operator = (const QtDimensionsSelectorPanel&)
 {
 	MGX_FORBIDDEN ("QtDimensionsSelectorPanel assignment operator is not allowed.");
 	return *this;

--- a/src/QtComponents/protected/QtComponents/QtDimensionsSelectorPanel.h
+++ b/src/QtComponents/protected/QtComponents/QtDimensionsSelectorPanel.h
@@ -71,16 +71,23 @@ class QtDimensionsSelectorPanel : public QWidget
 	/**
 	 * \return		Les dimensions sélectionnables.
 	 * \see			setAllowedDimensions
+	 * \see			isDimensionAllowed
 	 */
 	virtual Mgx3D::Utils::SelectionManagerIfc::DIM getAllowedDimensions ( ) const;
-
+	
+	/**
+	 * \return		true si la dimension transmise en argument est séleectionnable, false dans le cas contraire.
+	 * \see			setAllowedDimensions
+	 * \see			getAllowedDimensions
+	 */
+	virtual bool isDimensionAllowed (Mgx3D::Utils::SelectionManagerIfc::DIM dimension) const;
+	
 	/**
 	 * Actualise le panneau conformément aux dimensions reçues en argument.
 	 * \param		Nouvelles dimensions sélectionnables.
 	 * \see			getAllowedDimensions
 	 */
-	virtual void setAllowedDimensions (
-							Mgx3D::Utils::SelectionManagerIfc::DIM dimensions);
+	virtual void setAllowedDimensions (Mgx3D::Utils::SelectionManagerIfc::DIM dimensions);
 
 
 	signals :
@@ -109,11 +116,13 @@ class QtDimensionsSelectorPanel : public QWidget
 	QtDimensionsSelectorPanel& operator = (const QtDimensionsSelectorPanel&);
 
 	/** La gestion exclusive ou non de la dimension. */
-	QButtonGroup*					_buttonGroup;
+	QButtonGroup*							_buttonGroup;
 
 	/** Les dimensions possibles. */
-	QCheckBox						*_d0CheckBox, *_d1CheckBox, *_d2CheckBox,
-									*_d3CheckBox;
+	QCheckBox								*_d0CheckBox, *_d1CheckBox, *_d2CheckBox, *_d3CheckBox;
+	
+	/** Les dimensions autorisées. */
+	Mgx3D::Utils::SelectionManagerIfc::DIM	_allowedDimensions;
 };	// class QtDimensionsSelectorPanel
 
 


### PR DESCRIPTION
Fixed QtDimensionsSelectorPanel::getDimensions which wrongly returned D0 because its parent widget was disabled.