### PR TITLE
Issue 196 Fix: Face cutting preview does not update when changing ope…

### DIFF
--- a/src/QtComponents/QtTopologySplitFacesAction.cpp
+++ b/src/QtComponents/QtTopologySplitFacesAction.cpp
@@ -427,26 +427,22 @@ void QtTopologySplitFacesPanel::preview (bool show, bool destroyInteractor)
 					throw Exception (UTF8String ("QtTopologySplitFacesPanel::preview : cas non implémenté.", Charset::UTF_8));
 			}	// switch (getCutDefinitionMethod ( ))
 		}	// else if (true == allFaces ( ))
-		CHECK_NULL_PTR_ERROR (command.get ( ))
-		RenderingManager::CommandPreviewMgr	previewManager (
-							*command.get ( ), getRenderingManager ( ), true);
+		
+		{	// Bloc pour forcer la destruction de previewManager (qui ajoute les acteurs VTK à la scène) avant de faire le forceRender ( ).
+			CHECK_NULL_PTR_ERROR (command.get ( ))
+			RenderingManager::CommandPreviewMgr	previewManager (*command.get ( ), getRenderingManager ( ), true);
 
-		// Ajouter les infos de pré-maillage ?
-		if (0 != edge->getDisplayProperties ( ).getGraphicalRepresentation( ))
-		{
-			const DisplayProperties&	props	=
-				true == getRenderingManager ( ).useGlobalDisplayProperties ( ) ?
-				getRenderingManager ( ).getContext ( ).globalDisplayProperties (
-					edge->getType ( )) : edge->getDisplayProperties ( );
-			const unsigned long		mask	=
-				true == getRenderingManager ( ).useGlobalDisplayProperties ( ) ?
-				getRenderingManager().getContext().globalMask(edge->getType()) :
-				edge->getDisplayProperties ( ).getGraphicalRepresentation (
-													)->getRepresentationMask( );
+			// Ajouter les infos de pré-maillage ?
+			if (0 != edge->getDisplayProperties ( ).getGraphicalRepresentation( ))
+			{
+				const DisplayProperties&	props	= true == getRenderingManager ( ).useGlobalDisplayProperties ( ) ? 
+						getRenderingManager ( ).getContext ( ).globalDisplayProperties (edge->getType ( )) : edge->getDisplayProperties ( );
+				const unsigned long		mask	= true == getRenderingManager ( ).useGlobalDisplayProperties ( ) ?
+					getRenderingManager().getContext().globalMask(edge->getType()) : edge->getDisplayProperties ( ).getGraphicalRepresentation ( )->getRepresentationMask( );
 
-			previewEdges (*command, previewManager, InfoCommand::CREATED,
-			              props, mask);
-		}	// if (0 != edge->getDisplayProperties ( )...
+				previewEdges (*command, previewManager, InfoCommand::CREATED, props, mask);
+			}	// if (0 != edge->getDisplayProperties ( )...
+		}
 
 		getRenderingManager ( ).forceRender ( );
 


### PR DESCRIPTION
…ration parameters (need to hover over the graphics window with the mouse cursor).

Script test :

# Création du sommet Pt0000
ctx.getGeomManager().newVertex (Mgx3D.Point(0, 0, 0))
# Création du sommet Pt0001
ctx.getGeomManager().newVertex (Mgx3D.Point(2, 0, 0))
# Création du sommet Pt0002
ctx.getGeomManager().newVertex (Mgx3D.Point(2, 1, 0))
# Création du sommet Pt0003
ctx.getGeomManager().newVertex (Mgx3D.Point(0, 1, 0))
# Création du segment Crb0000
ctx.getGeomManager().newSegment("Pt0000", "Pt0001")
# Création du segment Crb0001
ctx.getGeomManager().newSegment("Pt0001", "Pt0002")
# Création du segment Crb0002
ctx.getGeomManager().newSegment("Pt0002", "Pt0003")
# Création du segment Crb0003
ctx.getGeomManager().newSegment("Pt0003", "Pt0000")
# Création de la surface Surf0000
ctx.getGeomManager ( ).newPlanarSurface (["Crb0000","Crb0001","Crb0002","Crb0003"], "")
# Création d'une face topologique structurée sur une géométrie (Surf0000)
ctx.getTopoManager().newStructuredTopoOnGeometry ("Surf0000")