### PR TITLE
issue-200 : incorrect order when defining a rotation with three points

### DIFF
--- a/src/QtComponents/QtMgx3DRotationPanel.cpp
+++ b/src/QtComponents/QtMgx3DRotationPanel.cpp
@@ -226,9 +226,9 @@ Math::Rotation QtMgx3DRotationPanel::getRotation ( ) const
 	}
 	else if (0 != vertices3Panel)
 	{
-		// ordre des points pour vertices3Panel : P1, P2, Centre
+		// ordre des points pour vertices3Panel : center, start, end
 		vertices3Panel->getPoints (p1, p2, p3);
-		rotation	= Rotation (p3, p1, p2);
+		rotation	= Rotation (p1, p2, p3);
 	}
 	else
 	{


### PR DESCRIPTION
The rotations when defined by three points in the GUI asked in the panels for `[center, start, end]` but treated them as `[start, end, center]`. 

The order is now fixed; it affects :
- rotations, for both geometry and blocking entities
- geometry creation by revolution

The scripts are re-playable with no issue, assuming that the intended rotation was used.