### PR TITLE
Issue 186 (EB). Display in the history tab the position of the focal …

### DIFF
--- a/src/QtVtkComponents/VTKRenderingManager.cpp
+++ b/src/QtVtkComponents/VTKRenderingManager.cpp
@@ -964,6 +964,21 @@ VTKRenderingManager::~VTKRenderingManager ( )
 }	// VTKRenderingManager::~VTKRenderingManager
 
 
+void VTKRenderingManager::setContext (Mgx3D::Internal::Context* context)
+{
+	RenderingManager::setContext (context);
+	
+	try
+	{
+		getMgx3DInteractorStyle ().SetGUILogOutputStream (0);
+		getMgx3DInteractorStyle ().SetGUILogOutputStream (&getContext ( ).getLogDispatcher ( ));
+	}
+	catch (...)
+	{
+	}
+}
+
+
 QtVtkGraphicWidget& VTKRenderingManager::getVTKWidget ( )
 {
 	CHECK_NULL_PTR_ERROR (_vtkWidget)

--- a/src/QtVtkComponents/protected/QtVtkComponents/VTKRenderingManager.h
+++ b/src/QtVtkComponents/protected/QtVtkComponents/VTKRenderingManager.h
@@ -63,6 +63,18 @@ class VTKRenderingManager : public QtComponents::RenderingManager
 	virtual ~VTKRenderingManager ( );
 
 	/**
+	 * Le contexte d'utilisation du gestionnaire de rendu.
+	 */
+	//@{
+
+	/*
+	 * \param		Nouveau contexte d'utilisation du gestionnaire de rendu.
+	 */
+	virtual void setContext (Mgx3D::Internal::Context* context);
+
+	//@}	// Le contexte d'utilisation du gestionnaire de rendu.
+
+	/**
 	 * Les entités représentées.
 	 */
 	//@{

--- a/src/QtVtkComponents/protected/QtVtkComponents/vtkMgx3DInteractorStyle.h
+++ b/src/QtVtkComponents/protected/QtVtkComponents/vtkMgx3DInteractorStyle.h
@@ -16,6 +16,7 @@
 #include "QtComponents/EntitySeizureManager.h"
 #include "Utils/Entity.h"
 #include "Utils/SelectionManagerIfc.h"
+#include <TkUtil/LogOutputStream.h>
 
 #include <vtkHardwareSelector.h>
 #include <vtkSmartPointer.h>
@@ -243,6 +244,11 @@ class vtkMgx3DInteractorStyle : public vtkUnifiedInteractorStyle
 	virtual void SetCompletelyInsideSelection (bool on);
 	virtual bool GetCompletelyInsideSelection ( ) const;
 	
+	/** (Dés)Associer un flux de messages dans l'IHM à cet interacteur.
+	 */
+	virtual void SetGUILogOutputStream (TkUtil::LogOutputStream*);
+	virtual TkUtil::LogOutputStream* GetGUILogOutputStream ( );
+	
 	
 	protected :
 
@@ -330,6 +336,9 @@ class vtkMgx3DInteractorStyle : public vtkUnifiedInteractorStyle
 	
 	/** Un sélecteur pour le picking précis de premier plan. */
 	vtkSmartPointer<vtkHardwareSelector>			HardwareSelector;
+	
+	/** Un flux d'affichage d'infos sur les interactions dans l'IHM. */
+	TkUtil::LogOutputStream*						GUILogOutputStream;
 };	// class vtkMgx3DInteractorStyle
 
 


### PR DESCRIPTION
…point after a change via pressing the f key on an entity. The purpose is to make freehand distance measurements using the python console via (Mgx3D.Point(0, 0, 0) - Mgx3D.Point(2, 0, 0)).norme(), the result being displayed in the python outputs tab.