### PR TITLE
issue-202 Fix isnearlyequal floating point comparison

### DIFF
--- a/src/Utils/protected/Utils/MgxNumeric.h
+++ b/src/Utils/protected/Utils/MgxNumeric.h
@@ -8,6 +8,7 @@
 #ifndef MGX_NUMERIC_H
 #define MGX_NUMERIC_H
 
+#include <algorithm>
 #include <numeric>
 #include <cmath>
 #include <string>
@@ -68,14 +69,22 @@ namespace Math
 		static size_t				mgxDoubleFixedNotationCharMax;	
 #endif	// SWIG
 
-		static inline bool isNearlyEqual(const double a, const double b)
+		static inline bool isNearlyEqual(double a, double b)
 		{
-			double s = std::fabs(a) + std::abs(b);
-			double d = a - b;
-			return (d==0.0) ? true : isNearlyZero(d/s);
+            if(a == b) {
+                return true;
+            } else {
+                auto d = std::abs(a - b);
+                if (a == 0.0 || b == 0.0) {
+                    return isNearlyZero(d);
+                } else {
+                    auto s = std::max(std::abs(a), std::abs(b));
+                    return d <= s * Mgx3D::Utils::Math::MgxNumeric::mgxDoubleEpsilon;
+                }
+            }
 		}
 
-		static inline bool isNearlyZero (const double & u)
+		static inline bool isNearlyZero (double u)
 		{
 			return std::fabs(u) < Mgx3D::Utils::Math::MgxNumeric::mgxDoubleEpsilon;
 		}	// isNearlyZero

--- a/test_link/test_get_entity_at.py
+++ b/test_link/test_get_entity_at.py
@@ -1,0 +1,15 @@
+import pyMagix3D as Mgx3D
+import pytest
+
+def test_getVertexAt():
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    gm = ctx.getGeomManager ()
+    ctx.getGeomManager().newVertex (Mgx3D.Point(0, 0, 0))
+    pt0 = gm.getVertexAt(Mgx3D.Point(0, 0, 0))
+    assert pt0 == "Pt0000"
+    pt1 = gm.getVertexAt(Mgx3D.Point(1e-14, 0, 0))
+    assert pt1 == "Pt0000"
+    with pytest.raises(RuntimeError) as excinfo:
+        pt2 = gm.getVertexAt(Mgx3D.Point(1e-12, 0, 0))
+    assert "getVertexAt impossible, on trouve 0 sommets" in str(excinfo.value)


### PR DESCRIPTION
https://github.com/LIHPC-Computational-Geometry/magix3d/pull/33 introduces a bug, where `isNearlyEqual(a, b)` returns false when `(a == 0) xor (b == 0)` (it is an exclusive or), even when the other argument is near zero.

We might have to properly investigate further for a more reliable check, but this fix should do in the meantime.

Careful, as it affects the `Utils::Math::Point operator ==` it is widely used in all kinds of situations by quite a lot of the methods