### PR TITLE
add test rotate

### DIFF
--- a/test_link/test_rotate.py
+++ b/test_link/test_rotate.py
@@ -1,0 +1,13 @@
+import pyMagix3D as Mgx3D
+
+def test_rotate_box():
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    tm = ctx.getTopoManager ()
+    gm = ctx.getGeomManager ()
+    tm.newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
+    vol = gm.getVolumeAt([Mgx3D.Point(0, 0, 1), Mgx3D.Point(0, 0, 0), Mgx3D.Point(0, 1, 1), Mgx3D.Point(0, 1, 0), Mgx3D.Point(1, 0, 1), Mgx3D.Point(1, 0, 0), Mgx3D.Point(1, 1, 1), Mgx3D.Point(1, 1, 0)])
+    assert vol == 'Vol0000'
+    gm.rotate (["Vol0000"], Mgx3D.RotX(90))
+    img = gm.getVolumeAt([Mgx3D.Point(0, -1, 0), Mgx3D.Point(0, 0, 0), Mgx3D.Point(0, -1, 1), Mgx3D.Point(0, 0, 1), Mgx3D.Point(1, -1, 0), Mgx3D.Point(1, 0, 0), Mgx3D.Point(1, -1, 1), Mgx3D.Point(1, 0, 1)])
+    assert img == 'Vol0000'


### PR DESCRIPTION
Add a test for the rotate function.

This PR should be merged after #104 because the `gm.getVolumeAt` method currently fails due to the `Utils::Math::Point operator==` incorrect implementation.