### PR TITLE
issue-209 : generated command for edge discretization with geometric progression and fixed first length badly formatted

### DIFF
--- a/src/Core/Topo/EdgeMeshingPropertyGeometric.cpp
+++ b/src/Core/Topo/EdgeMeshingPropertyGeometric.cpp
@@ -209,17 +209,18 @@ getScriptCommand() const
 {
     TkUtil::UTF8String o (TkUtil::Charset::UTF_8);
     o << getMgx3DAlias() << ".EdgeMeshingPropertyGeometric("
-      << (long)m_nb_edges <<","
+      << (long)m_nb_edges <<", "
       << Utils::Math::MgxNumeric::userRepresentation(m_raison);
     if (isPolarCut())
     	o << ", "<<getPolarCenter().getScriptCommand();
-    if (!getDirect())
-    	o << ", False";
-    if (m_initWithArm1){
-    	 if (getDirect())
-    		 o << ", True"; // sinon Python bloque
-    	o << ","<<Utils::Math::MgxNumeric::userRepresentation(m_arm1);
+    if (m_initWithArm1) {
+        o << (getDirect() ? std::string(", True") : std::string(", False"));
+        o << ", True"; // this is for m_initWithArm1
+        o << ", " << Utils::Math::MgxNumeric::userRepresentation(m_arm1);
     }
+    else if (!getDirect())
+            o << ", False";
+
     o << ")";
     return o;
 }


### PR DESCRIPTION
The generated command seems to be missing a boolean parameter :
```python
emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, True, 0.05)
ctx.getTopoManager().setMeshingProperty (emp, ["Ar0005"])
```

Should be `(nb, ratio, isDirect, isFixedLength, length)`
```python
emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, True, True, 0.05)
ctx.getTopoManager().setMeshingProperty (emp, ["Ar0005"])
```