### PR TITLE
issue-207 : clarified error message when writeMli and VTK failed due to mesh qual…

### DIFF
--- a/src/Core/Mesh/MeshImplementation.cpp
+++ b/src/Core/Mesh/MeshImplementation.cpp
@@ -323,7 +323,9 @@ void MeshImplementation::writeMli(std::string nom)
     // on ajoute les groupes de mailles de gmds
     bool isCreateGMDSGroupsOK = createGMDSGroups();
     if(!isCreateGMDSGroupsOK) {
-    	throw TkUtil::Exception (TkUtil::UTF8String ("MeshImplementation::writeMli ne peut créer les groupes.", TkUtil::Charset::UTF_8));
+    	throw TkUtil::Exception (TkUtil::UTF8String ("MeshImplementation::writeMli ne peut créer les groupes."
+                                                     "Veuillez fermer les panneaux qualité ou désafficher les classes de mailles de ces panneaux.",
+                                                     TkUtil::Charset::UTF_8));
     }
 
     try {
@@ -382,7 +384,9 @@ void MeshImplementation::writeVTK(std::string nom)
     // on ajoute les groupes de mailles de gmds
 	bool isCreateGMDSGroupsOK = createGMDSGroups();
 	if(!isCreateGMDSGroupsOK) {
-	  	throw TkUtil::Exception (TkUtil::UTF8String ("MeshImplementation::writeVTK ne peut créer les groupes.", TkUtil::Charset::UTF_8));
+	  	throw TkUtil::Exception (TkUtil::UTF8String ("MeshImplementation::writeVTK ne peut créer les groupes."
+                                                     "Veuillez fermer les panneaux qualité ou désafficher les classes de mailles de ces panneaux.",
+                                                     TkUtil::Charset::UTF_8));
 	}
 
 	try{


### PR DESCRIPTION
…ity classes begin displayed.

Writing the mesh, using `writeMli` or `writeVTK` fails with a cryptic error message `MeshImplementation::writeMli ne peut créer les groupes`.

As this happens when cell quality classes, from the mesh quality panels, are displayed, the message is now updated with a suggestion to close the quality panels or not display any cell quality class prior to writing the mesh.