### PR TITLE
Python msg error twice fix

### DIFF
--- a/src/QtComponents/QtMgx3DMainWindow.cpp
+++ b/src/QtComponents/QtMgx3DMainWindow.cpp
@@ -4516,10 +4516,6 @@ void QtMgx3DMainWindow::displayCommandError (const TkUtil::UTF8String& message)
 							command.setUserNotified (true);
 							QtMessageBox::systemNotification ("Magix3D", QtMgx3DApplication::getAppIcon ( ), "Commandes terminées en erreur.", QtMessageBox::URGENCY_NORMAL, Resources::instance ( )._commandNotificationDuration);
 							displayCommandError (command.getErrorMessage ( ));
-/*							if (false == Resources::instance ( )._showAmodalDialogOnCommandError.getValue ( ))
-								QtMessageBox::displayErrorMessage (this, getAppTitle ( ), command.getErrorMessage ( ));	// défaut
-							else
-								QtMessageBox::displayErrorMessageInAppWorkspace (this, getAppTitle ( ), command.getErrorMessage ( ));	// Expérimental, Issue#112	*/
 						}
 
 						// pour permettre de rejouer cette commande qui a échouée, elle est transmise avec le status en erreur, cela peut permettre de la corriger

--- a/src/QtComponents/QtMgx3DPythonConsole.cpp
+++ b/src/QtComponents/QtMgx3DPythonConsole.cpp
@@ -180,7 +180,8 @@ void QtMgx3DPythonConsole::run ( )
 	storePolicy ( );
 	
 	ActionCompletionNotifier actionCompletionNotifier (getAppName ( ), QtMgx3DApplication::getAppIcon ( ), UTF8String ("Instructions python exécutées", Charset::UTF_8), QtMessageBox::URGENCY_NORMAL, Resources::instance ( )._commandNotificationDuration, Resources::instance ( )._commandNotificationDelay);
-
+	AutoDisableCommandsErrorsNotifications	autoDisableCommandsErrorsNotifications (getMainWindow ( ));
+	
 	try
 	{
 		QtPythonConsole::run ( );

--- a/src/QtComponents/protected/QtComponents/QtMgx3DMainWindow.h
+++ b/src/QtComponents/protected/QtComponents/QtMgx3DMainWindow.h
@@ -512,6 +512,20 @@ class QtMgx3DMainWindow :
 	 */
 	virtual bool actionsDisabled ( ) const;
 	virtual bool disableActions (bool);
+	
+	/**
+	 * Désactiver l'affichage de messages d'erreur relatifs à l'exécution des commandes (éviter les doublons).
+	 * @see		AutoDisableCommandsErrorsNotifications
+	 */
+	virtual bool commandsErrorsNotificationsDisabled ( ) const;
+	virtual void disableCommandsErrorsNotifications (bool disable);
+	
+	/**
+	 * Affiche le message d'erreur transmis en argument et relatif à l'exécution d'une commande si l'affichage de tels
+	 * messages n'est pas désactivé.
+	 * @see		disableCommandsErrorsNotifications
+	 */
+	virtual void displayCommandError (const TkUtil::UTF8String& message);
 
 	//@}	// Les opérations.
 
@@ -1532,7 +1546,7 @@ class QtMgx3DMainWindow :
 								*_cadMenu, *_topologyMenu,
 								*_meshingMenu, *_selectionMenu,	
 								*_roomMenu,	*_toolsMenu, *_helpMenu;
-	bool							_actionsDisabled;
+	bool						_actionsDisabled, _commandErrorsNotificationsDisabled;
 
 	/** Les commandes python. */
 	QtMgx3DPythonConsole*								_pythonPanel;
@@ -1704,6 +1718,26 @@ class QtMgx3DStateView : public QWidget
 	QTimer*								_labelTimer;
 };	// class QtMgx3DStateView
 
+
+/**
+ * Classe permettant de désactiver l'affichage de messages d'erreur relatifs à l'exécution des commandes et de réactiver automatiquement le service
+ * en fin de vie de l'instance.
+ */
+class AutoDisableCommandsErrorsNotifications
+{
+	public :
+	
+	AutoDisableCommandsErrorsNotifications (QtMgx3DMainWindow*);
+	~AutoDisableCommandsErrorsNotifications ( );
+
+
+	private :
+	
+	AutoDisableCommandsErrorsNotifications (const AutoDisableCommandsErrorsNotifications&);
+	AutoDisableCommandsErrorsNotifications& operator = (const AutoDisableCommandsErrorsNotifications&);
+	QtMgx3DMainWindow*	_mainWindow;
+	bool				_initialState;
+};	// class AutoDisableCommandsErrorsNotifications
 
 }	// namespace QtComponents
 


### PR DESCRIPTION
Fix: Error messages are only displayed once when commands are executed via the python interpreter