### PR TITLE
issue-206: interpolated edge error message

### DIFF
--- a/src/Core/Topo/CoEdge.cpp
+++ b/src/Core/Topo/CoEdge.cpp
@@ -2408,9 +2408,18 @@ check() const
     	CHECK_NULL_PTR_ERROR(empi);
 
 		if (empi->getType() == EdgeMeshingPropertyInterpolate::with_coedge_list){
-			std::vector<std::string> coedges = empi->getCoEdges();
-			for (uint i=0; i<coedges.size(); i++)
-				getContext().getLocalTopoManager().getCoEdge(coedges[i], true);
+            try {
+                std::vector<std::string> coedges = empi->getCoEdges();
+                for (uint i = 0; i < coedges.size(); i++)
+                    getContext().getLocalTopoManager().getCoEdge(coedges[i], true);
+            }
+            catch (Utils::IsDestroyedException e)
+            {
+                TkUtil::UTF8String messErr (TkUtil::Charset::UTF_8);
+                messErr << "Erreur avec l'arête commune "<<getName()
+                        <<" dont la discrétisation est interpolée par rapport à des arêtes de référence dont l'une au moins est détruite ("<<e.getMessage()<<")";
+                throw TkUtil::Exception(messErr);
+            }
 		}
 		else if (empi->getType() == EdgeMeshingPropertyInterpolate::with_coface){
 			try {

--- a/test_link/test_edge_interpolate.py
+++ b/test_link/test_edge_interpolate.py
@@ -1,0 +1,24 @@
+import pyMagix3D as Mgx3D
+import pytest
+
+def test_edgeInterpolate_destroy():
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    tm = ctx.getTopoManager ()
+    mm = ctx.getMeshManager ()
+    tm.newTopoVertex (Mgx3D.Point(0, 0, 0),"")
+    tm.newTopoVertex (Mgx3D.Point(1, 0, 0),"")
+    tm.newTopoVertex (Mgx3D.Point(1, 1, 0),"")
+    tm.newTopoVertex (Mgx3D.Point(0, 1, 0),"")
+    tm.newTopoVertex (Mgx3D.Point(2, 0, 0),"")
+    tm.newTopoVertex (Mgx3D.Point(2, 1, 0),"")
+    tm.newTopoEntity (["Som0000", "Som0001", "Som0002", "Som0003"], 2, "")
+    tm.newTopoEntity (["Som0001", "Som0004", "Som0005", "Som0002"], 2, "")
+    emp = Mgx3D.EdgeMeshingPropertyInterpolate(10, ["Ar0005"])
+    tm.setMeshingProperty (emp, ["Ar0001"])
+    tm.destroy (["Fa0001"], True)
+    # the meshing property of Ar0001 references Ar0005, which is destroyed
+    # along with Fa0001. Thus, Ar0001 becomes unmeshable
+    with pytest.raises(RuntimeError) as excinfo:
+        ctx.getMeshManager().newAllFacesMesh()
+    assert "Ar0001" in str(excinfo.value)


### PR DESCRIPTION
When meshing an edge `A` that references (`interpolation`) another edge `B`, in the case where `B` was destroyed, thus making `A` unmeshable, the error message does not mention `A`.

I makes resolving the issue harder, `A` should be mentioned so that the user can adjust its meshing property.