### PR TITLE
issue-213: blocks created from faces by extrusion (MakeBlocksByExtrusion) are no…

### DIFF
--- a/src/Core/Topo/CommandExtrudeFace.cpp
+++ b/src/Core/Topo/CommandExtrudeFace.cpp
@@ -19,6 +19,7 @@
 
 
 #include "Group/Group2D.h"
+#include "Group/Group3D.h"
 
 //#define _DEBUG_MESH_LAW
 /*----------------------------------------------------------------------------*/
@@ -508,8 +509,14 @@ namespace Mgx3D {
                 } // end for i<coface_0->getNbEdges()
 
                 Block* newBlock = new Topo::Block(getContext(), faces, vertices, true);
+
+                Group::Group3D *group = getContext().getLocalGroupManager().getNewGroup3D(getContext().getLocalGroupManager().getDefaultName(3),
+                                                                                          &getInfoCommand());
+                group->add(newBlock);
+                newBlock->getGroupsContainer().add(group);
+                getInfoCommand().addGroupInfoEntity(group,Internal::InfoCommand::DISPMODIFIED);
+
                 getInfoCommand().addTopoInfoEntity(newBlock, Internal::InfoCommand::CREATED);
-                //updateGeomAssociation(coface_0->getGeomAssociation(), newBlock);
 #ifdef _DEBUG2
                 std::cout<<"\nCréation du bloc : "<<*newBlock;
         //newBlock->check();

--- a/test_link/test_makeblocksbyextrude.py
+++ b/test_link/test_makeblocksbyextrude.py
@@ -1,0 +1,11 @@
+import pyMagix3D as Mgx3D
+
+def test_makeblocksbyextrude():
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    tm = ctx.getTopoManager ()
+    tm.newSphereWithTopo (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Portion.ENTIER, True, .5, 10, 10)
+    tm.makeBlocksByExtrude (["Fa0010", "Fa0040"],Mgx3D.Vector(-1, 0, 1))
+    gg = ctx.getGroupManager()
+    blocklist = gg.getTopoBlocks(["Hors_Groupe_3D"])
+    assert len(blocklist) == 9


### PR DESCRIPTION
…w in Hors_Groupe_3D

The blocs `Bl0007 Bl0008` were part of no group and thus were not displayable.

```python
# Création d'une sphère avec une topologie
ctx.getTopoManager().newSphereWithTopo (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Portion.ENTIER, True, .5, 10, 10)
# Extrusion de la topologie
ctx.getTopoManager().makeBlocksByExtrude (["Fa0010", "Fa0040"],Mgx3D.Vector(-1, 0, 1))
```