### PR TITLE
Optimization of the display of topological entities during interactio…

### DIFF
--- a/src/Core/Internal/Resources.cpp
+++ b/src/Core/Internal/Resources.cpp
@@ -34,6 +34,8 @@ _allowThreadedFacePreMeshTasks ("allowThreadedFacePreMeshTasks", true, UTF8Strin
 _allowThreadedBlockPreMeshTasks ("allowThreadedBlockPreMeshTasks", true, UTF8String ("true si le prémaillage des blocs peut être décomposé en plusieurs tâches exécutées parallèlement dans plusieurs threads, false si l'exécution doit être séquentielle.")),
 _displayScriptOutputs ("displayScriptOutputs", true, UTF8String ("true si le programme doit afficher les sorties des commandes script, false dans le cas contraire.")),
 _memorizeEdgePreMesh ("memorizeEdgePreMesh", true, UTF8String ("true si le programme doit mémoriser le prémaillage des arêtes, false dans le cas contraire.")),
+_lodPointSize ("lodPointSize", 1, UTF8String ("Taille des points/noeuds/vertex lors des interactions.", Charset::UTF_8)),
+_lodLineWidth ("lodLineWidth", 1, UTF8String ("Epaisseur des lignes/arêtes lors des interactions.", Charset::UTF_8)),
 _fontFamily ("fontFamily", "Arial", UTF8String ("Police de caractères utilisée pour les affichages graphiques. Valeurs possibles : Arial, Times, Courier.", Charset::UTF_8)),
 _fontSize ("fontSize", 12, UTF8String ("Taille de la police de caractères utilisée pour les affichages graphiques.", Charset::UTF_8)),
 _fontBold ("bold", false, UTF8String ("Caractère gras de la police de caractères utilisée pour les affichages graphiques. Si true la police est grasse.", Charset::UTF_8)),
@@ -104,7 +106,10 @@ _loadGuiState ("loadGuiState", true, UTF8String ("True si l'état de l'IHM (posi
 _geomDestroyOnHide ("destroyOnHide", false, UTF8String ("True si la représentation graphique des entités géométriques doit être détruite lorsque ces entités ne sont plus affichées, false dans le cas contraire.", Charset::UTF_8)),
 _topoDestroyOnHide ("destroyOnHide", false, UTF8String ("True si la représentation graphique des entités topologiques doit être détruite lorsque ces entités ne sont plus affichées, false dans le cas contraire.", Charset::UTF_8)),
 _meshDestroyOnHide ("destroyOnHide", true, UTF8String ("True si la représentation graphique des entités de maillage doit être détruite lorsque ces entités ne sont plus affichées, false dans le cas contraire.", Charset::UTF_8)),
-
+_topoVertexLodNumberThreshold ("topoVertexLodNumberThreshold", 250, UTF8String ("Nombre maximum de vertex topologiques à afficher lors d'interactions.", Charset::UTF_8)),
+_topoEdgeLodNumberThreshold ("topoEdgeLodNumberThreshold", 250, UTF8String ("Nombre maximum d'arêtes topologiques à afficher lors d'interactions.", Charset::UTF_8)),
+_topoFaceLodNumberThreshold ("topoFaceLodNumberThreshold", 250, UTF8String ("Nombre maximum de faces topologiques à afficher lors d'interactions.", Charset::UTF_8)),
+_topoBlockLodNumberThreshold ("topoBlockLodNumberThreshold", 250, UTF8String ("Nombre maximum de blocs topologiques à afficher lors d'interactions.", Charset::UTF_8)),
 
 _organisation ("CEA.DAM.DSSI"),
 _softwareName ("Magix3D"),
@@ -130,6 +135,8 @@ _allowThreadedFacePreMeshTasks ("allowThreadedFacePreMeshTasks", true, UTF8Strin
 _allowThreadedBlockPreMeshTasks ("allowThreadedBlockPreMeshTasks", true, UTF8String ("true si le prémaillage des blocs peut être décomposé en plusieurs tâches exécutées parallèlement dans plusieurs threads, false si l'exécution doit être séquentielle.")),
 _displayScriptOutputs ("displayScriptOutputs", true, UTF8String ("true si le programme doit afficher les sorties des commandes script, false dans le cas contraire.")),
 _memorizeEdgePreMesh ("memorizeEdgePreMesh", true, UTF8String ("true si le programme doit mémoriser le prémaillage des arêtes, false dans le cas contraire.")),
+_lodPointSize ("lodPointSize", 1, UTF8String ("Taille des points/noeuds/vertex lors des interactions.", Charset::UTF_8)),
+_lodLineWidth ("lodLineWidth", 1, UTF8String ("Epaisseur des lignes/arêtes lors des interactions.", Charset::UTF_8)),
 _fontFamily ("fontFamily", "Arial", "Police de caractères utilisée pour les affichages graphiques. Valeurs possibles : Arial, Times, Courier."),
 _fontSize ("fontSize", 12, "Taille de la police de caractères utilisée pour les affichages graphiques."),
 _fontBold ("bold", false, "Caractère gras de la police de caractères utilisée pour les affichages graphiques. Si true la police est grasse."),
@@ -200,7 +207,10 @@ _loadGuiState ("loadGuiState", true, "True si l'état de l'IHM (position, taille
 _geomDestroyOnHide ("destroyOnHide", false, "True si la représentation graphique des entités géométriques doit être détruite lorsque ces entités ne sont plus affichées, false dans le cas contraire."),
 _topoDestroyOnHide ("destroyOnHide", false, "True si la représentation graphique des entités topologiques doit être détruite lorsque ces entités ne sont plus affichées, false dans le cas contraire."),
 _meshDestroyOnHide ("destroyOnHide", true, "True si la représentation graphique des entités de maillage doit être détruite lorsque ces entités ne sont plus affichées, false dans le cas contraire."),
-
+_topoVertexLodNumberThreshold ("topoVertexLodNumberThreshold", 250, UTF8String ("Nombre maximum de vertex topologiques à afficher lors d'interactions.", Charset::UTF_8)),
+_topoEdgeLodNumberThreshold ("topoEdgeLodNumberThreshold", 250, UTF8String ("Nombre maximum d'arêtes topologiques à afficher lors d'interactions.", Charset::UTF_8)),
+_topoFaceLodNumberThreshold ("topoFaceLodNumberThreshold", 250, UTF8String ("Nombre maximum de faces topologiques à afficher lors d'interactions.", Charset::UTF_8)),
+_topoBlockLodNumberThreshold ("topoBlockLodNumberThreshold", 250, UTF8String ("Nombre maximum de blocs topologiques à afficher lors d'interactions.", Charset::UTF_8)),
 
 _organisation ("CEA.DAM.DSSI"),
 _softwareName ("Magix3D"),

--- a/src/Core/protected/Internal/Resources.h
+++ b/src/Core/protected/Internal/Resources.h
@@ -82,7 +82,13 @@ class Resources
 	 * Le prémaillage des arêtes, faces et blocs peut il être décomposé en plusieurs tâches exécutées parallèlement dans plusieurs threads ?
 	 */
 	Preferences::BoolNamedValue					_allowThreadedEdgePreMeshTasks, _allowThreadedFacePreMeshTasks, _allowThreadedBlockPreMeshTasks;
-	
+
+	/** La taille des points/noeuds/vertex lors des interactions. */
+	Preferences::UnsignedLongNamedValue			_lodPointSize;
+
+	/** L'épaisseur des lignes/arêtes lors des interactions. */
+	Preferences::UnsignedLongNamedValue			_lodLineWidth;
+
 	/**
 	 * La police de caractères à utiliser pour les affichages 2D dans la  fenêtre graphique. */
 	Preferences::StringNamedValue				_fontFamily;
@@ -459,6 +465,9 @@ class Resources
 	/** Faut-il détruire la représentation graphique des entités de maillage lorsqu'elles ne sont plus affichées ?
 	 */
 	Preferences::BoolNamedValue					_meshDestroyOnHide;
+
+	/** Les nombres d'entités maximum à afficher lors d'interactions. */
+	Preferences::UnsignedLongNamedValue			_topoVertexLodNumberThreshold, _topoEdgeLodNumberThreshold, _topoFaceLodNumberThreshold, _topoBlockLodNumberThreshold;
 
 	/** Les scripts à exécuter au lancement de l'application (arguments de ligne de commande suivant -scripts. */
 	std::vector<std::string>					_scripts;

--- a/src/QtComponents/QtMgx3DApplication.cpp
+++ b/src/QtComponents/QtMgx3DApplication.cpp
@@ -697,6 +697,8 @@ void QtMgx3DApplication::applyConfiguration (const Section& mainSection)
 		Section&	geomSection	= representationsSection.getSection ("geomEntities");
 		Section&	topoSection	= representationsSection.getSection ("topoEntities");
 		Section&	meshSection	= representationsSection.getSection ("meshEntities");
+		PreferencesHelper::getUnsignedLong (representationsSection, Resources::instance ( )._lodPointSize);
+		PreferencesHelper::getUnsignedLong (representationsSection, Resources::instance ( )._lodLineWidth);
 		PreferencesHelper::getString (representationsSection, Resources::instance ( )._fontFamily);
 		DisplayProperties::_defaultFontFamily	= fontNameToInt (Resources::instance ( )._fontFamily.getValue ( ));
 		PreferencesHelper::getUnsignedLong (representationsSection, Resources::instance ( )._fontSize);
@@ -708,6 +710,10 @@ void QtMgx3DApplication::applyConfiguration (const Section& mainSection)
 		PreferencesHelper::getBoolean (geomSection, Resources::instance ( )._geomDestroyOnHide);
 		PreferencesHelper::getBoolean (topoSection, Resources::instance ( )._topoDestroyOnHide);
 		PreferencesHelper::getBoolean (meshSection, Resources::instance ( )._meshDestroyOnHide);
+		PreferencesHelper::getUnsignedLong (topoSection, Resources::instance ( )._topoVertexLodNumberThreshold);
+		PreferencesHelper::getUnsignedLong (topoSection, Resources::instance ( )._topoEdgeLodNumberThreshold);
+		PreferencesHelper::getUnsignedLong (topoSection, Resources::instance ( )._topoFaceLodNumberThreshold);
+		PreferencesHelper::getUnsignedLong (topoSection, Resources::instance ( )._topoBlockLodNumberThreshold);
 
 		Internal::InternalPreferences::instance ( ).loadPreferences(representationsSection);
 	}
@@ -1012,6 +1018,8 @@ void QtMgx3DApplication::saveConfiguration (Section& mainSection)
 	Section&	geomSection	= PreferencesHelper::getSection (representationsSection, "geomEntities");
 	Section&	topoSection	= PreferencesHelper::getSection (representationsSection, "topoEntities");
 	Section&	meshSection	= PreferencesHelper::getSection (representationsSection, "meshEntities");
+	PreferencesHelper::updateUnsignedLong (representationsSection, Resources::instance ( )._lodPointSize);
+	PreferencesHelper::updateUnsignedLong (representationsSection, Resources::instance ( )._lodLineWidth);
 	PreferencesHelper::updateString (representationsSection, Resources::instance ( )._fontFamily);
 	PreferencesHelper::updateUnsignedLong (representationsSection, Resources::instance ( )._fontSize);
 	PreferencesHelper::updateBoolean (representationsSection, Resources::instance ( )._fontBold);
@@ -1019,6 +1027,10 @@ void QtMgx3DApplication::saveConfiguration (Section& mainSection)
 	PreferencesHelper::updateBoolean (geomSection, Resources::instance ( )._geomDestroyOnHide);
 	PreferencesHelper::updateBoolean (topoSection, Resources::instance ( )._topoDestroyOnHide);
 	PreferencesHelper::updateBoolean (meshSection, Resources::instance ( )._meshDestroyOnHide);
+	PreferencesHelper::updateUnsignedLong (topoSection, Resources::instance ( )._topoVertexLodNumberThreshold);
+	PreferencesHelper::updateUnsignedLong (topoSection, Resources::instance ( )._topoEdgeLodNumberThreshold);
+	PreferencesHelper::updateUnsignedLong (topoSection, Resources::instance ( )._topoFaceLodNumberThreshold);
+	PreferencesHelper::updateUnsignedLong (topoSection, Resources::instance ( )._topoBlockLodNumberThreshold);
 	Internal::InternalPreferences::instance ( ).savePreferences(representationsSection);
 
 	// Interacteur :

--- a/src/QtComponents/RenderedEntityRepresentation.cpp
+++ b/src/QtComponents/RenderedEntityRepresentation.cpp
@@ -216,7 +216,7 @@ Color RenderedEntityRepresentation::getBaseColor (unsigned long mask) const
 float RenderedEntityRepresentation::getPointSize (
 									const Entity& entity, unsigned long mask)
 {
-	const DisplayProperties	properties	= getDisplayPropertiesAttributes ( );
+//	const DisplayProperties	properties	= getDisplayPropertiesAttributes ( );
 	const DisplayProperties::GraphicalRepresentation*	rep	=
 		entity.getDisplayProperties ( ).getGraphicalRepresentation ( );
 	float pointSize	= entity.getDisplayProperties ( ).getPointSize ( );
@@ -235,7 +235,7 @@ float RenderedEntityRepresentation::getPointSize (
 float RenderedEntityRepresentation::getLineWidth (
 									const Entity& entity, unsigned long mask)
 {
-	float lineWidth	= 1;
+	float lineWidth	= 1.;
 	//const DisplayProperties&	properties	= entity.getDisplayProperties ( );
 	const DisplayProperties	properties	= getDisplayPropertiesAttributes ( );
 	const DisplayProperties::GraphicalRepresentation*	rep	=

--- a/src/QtVtkComponents/protected/QtVtkComponents/VTKMgx3DActor.h
+++ b/src/QtVtkComponents/protected/QtVtkComponents/VTKMgx3DActor.h
@@ -62,8 +62,7 @@ class VTKMgx3DActor : public vtkLODActor
 	 * \param		Le type de représentation portée par l'acteur.
 	 * \see			GetRepresentationType
 	 */
-	virtual void SetRepresentationType (
-									Mgx3D::Utils::DisplayRepresentation::type);
+	virtual void SetRepresentationType (Mgx3D::Utils::DisplayRepresentation::type);
 
 	/**
 	 * \return		Le type de représentation portée par l'acteur.
@@ -71,8 +70,7 @@ class VTKMgx3DActor : public vtkLODActor
 	 * \see			IsSolid
 	 * \see			IsWire
 	 */
-	virtual Mgx3D::Utils::DisplayRepresentation::type
-												GetRepresentationType ( ) const;
+	virtual Mgx3D::Utils::DisplayRepresentation::type GetRepresentationType ( ) const;
 
 	/**
 	 * \return		<I>true</I> si la représentation est solide, <I>false</I>
@@ -90,6 +88,13 @@ class VTKMgx3DActor : public vtkLODActor
 	 */
 	virtual bool IsWire ( ) const;
 
+	/**
+	 * \return		<I>true</I> si lors d'une interaction l'acteur doit être représenté en mode LOD (Level Of Detail) au sens
+	 *				Magix3D. En VTK en mode LOD une donnée sur n d'un dataset est représentée. Dans Magix3D la plupart des
+	 *				datasets ne contiennent qu'une donnée, et, en mode LOD, c'est un acteur sur n qui et affiché.
+	 */
+	virtual bool IsLodDisplayable ( ) const;
+	
 
 	protected :
 
@@ -111,6 +116,9 @@ class VTKMgx3DActor : public vtkLODActor
 
 	/** Le type de représentation de l'acteur. */
 	Mgx3D::Utils::DisplayRepresentation::type	_representationType;
+
+	/** Un nombre aléatoire compris entre 0 et 100 pour savoir si l'acteur doit être affiché en mode LOD. */
+	long										_lodAlea;
 };	// class VTKMgx3DActor
 
 

--- a/src/QtVtkComponents/protected/QtVtkComponents/vtkMgx3DInteractorStyle.h
+++ b/src/QtVtkComponents/protected/QtVtkComponents/vtkMgx3DInteractorStyle.h
@@ -22,6 +22,8 @@
 #include <vtkSmartPointer.h>
 #include <vtkUnsignedCharArray.h>
 
+#include <vector>
+
 
 /** <P>En plus de la classe <I>vtkUnifiedInteractorStyle</I> permet :<BR>
  * <OL>
@@ -74,6 +76,25 @@ class vtkMgx3DInteractorStyle : public vtkUnifiedInteractorStyle
 	 * Affiche des informations dans os sur l'instance.
 	 */
 	virtual void PrintSelf (ostream& os, vtkIndent indent);
+
+	/**
+	 * Une interaction est-elle en cours dans cette session Magix3D ?
+	 */
+	static bool	InInteraction ( );
+
+	/**
+	 * Affecte true à inInteraction puis vtkUnifiedInteractorStyle::StartState (newstate).
+	 * Désactive l'affichage des vtkMgx3DActor dont <I>IsLodDisplayable ( )</I> retourne
+	 * <I>false</I>, et paramètre les autres en affichage LOD (points/arêtes plus petits).
+	 */
+	virtual void StartState (int newstate);
+
+	/**
+	 * Affecte false à inInteraction puis vtkUnifiedInteractorStyle::StopState ( ), puis
+	 * restaure les paramètres d'affichage normaux des vtkMgx3DActor affichés, et restaure 
+	 * l'affichage des vtkMgx3DActor suspendus.
+	 */
+	virtual void StopState ( );
 
 	/** <P>Surcharge les actions suivantes :<BR>
 	 * <OL>
@@ -303,6 +324,12 @@ class vtkMgx3DInteractorStyle : public vtkUnifiedInteractorStyle
 	vtkMgx3DInteractorStyle (const vtkMgx3DInteractorStyle&);
 	vtkMgx3DInteractorStyle& operator = (const vtkMgx3DInteractorStyle&);
 
+	/** Une interaction utilisateur est-elle en cours dans cette session Magix3D ? */
+	static bool										InUserInteraction;
+	
+	/** Les acteurs suspendus lors d'une interaction dans la session Magix3D (émulation de mode LOD avec des acteurs n'affichant qu'une donnée. */
+	static std::vector<vtkActor*>					SuspendedActors;
+
 	/** Outils de sélection interactive à la souris. */
 	Mgx3D::QtVtkComponents::VTKMgx3DPicker*			Mgx3DPicker;
 	Mgx3D::QtVtkComponents::VTKMgx3DPickerCommand*	Mgx3DPickerCommand;
@@ -331,7 +358,7 @@ class vtkMgx3DInteractorStyle : public vtkUnifiedInteractorStyle
 	
 	/** Vaut <I>true</I> en mode sélection au <I>rectangle élastique</I> lorsque une entité doit être complétement dans le rectangle pour être sélectionnée,
 	 * <I>false</I> (défaut) si une intersection suffit. */
-	 bool											CompletelyInsideSelection;
+	bool											CompletelyInsideSelection;
 
 	/** Position du curseur de la souris au moment où le bouton est pressé. */
 	int												ButtonPressPosition [2];

--- a/src/QtVtkComponents/protected/QtVtkComponents/vtkMgx3DInteractorStyle.h
+++ b/src/QtVtkComponents/protected/QtVtkComponents/vtkMgx3DInteractorStyle.h
@@ -245,6 +245,8 @@ class vtkMgx3DInteractorStyle : public vtkUnifiedInteractorStyle
 	 * \see		SetInteractiveSelectionActivated
 	 */
 	virtual void OnRightButtonUp ( );
+	
+	virtual void OnMiddleButtonUp ( );
 
 	/**
 	 * \param	Gestionnaire de sélection <I>Magix 3D</I> associé.

--- a/src/QtVtkComponents/vtkMgx3DInteractorStyle.cpp
+++ b/src/QtVtkComponents/vtkMgx3DInteractorStyle.cpp
@@ -536,6 +536,10 @@ void vtkMgx3DInteractorStyle::OnLeftButtonDown ( )
 
 void vtkMgx3DInteractorStyle::OnMiddleButtonDown ( )
 {
+	vtkRenderWindowInteractor*	rwi	= this->Interactor;
+	if (0 != rwi)
+		rwi->GetEventPosition (ButtonPressPosition);
+
 	if ((false == GetInteractiveSelectionActivated ( )) || (false == isControlKeyPressed ( )))
 	{
 		vtkUnifiedInteractorStyle::OnMiddleButtonDown ( );
@@ -595,12 +599,23 @@ void vtkMgx3DInteractorStyle::OnRightButtonDown ( )
 void vtkMgx3DInteractorStyle::OnLeftButtonUp ( )
 {
 	// Arrêter un éventuel déclenchement d'interaction :
+	vtkRenderWindowInteractor*	rwi	= this->Interactor;
+	bool	doRender	= true;
+	if (0 != rwi)
+	{	// Ne rien afficher si absence de déplacement entre le début et la fin du clic :
+		int	pos [2];
+		rwi->GetEventPosition (pos);
+		if (0 == memcmp (pos, ButtonPressPosition, 2 * sizeof (int)))
+			doRender	= false;
+	}	// if (0 != rwi)
+	if ((false == doRender) && (0 != CurrentRenderer))
+		CurrentRenderer->DrawOff ( );
 	vtkUnifiedInteractorStyle::OnLeftButtonUp ( );
+	if ((false == doRender) && (0 != CurrentRenderer))
+		CurrentRenderer->DrawOn ( );
 
 	if (true == GetInteractiveSelectionActivated ( ))
 	{
-		vtkRenderWindowInteractor*	rwi	= this->Interactor;
-		
 		if (VTKIS_RUBBER_BAND != GetState ( ))
 		{
 			// Si le curseur n'a pas bougé depuis la pression sur le bouton, et que c'est paramétré tel que, on fait un picking :
@@ -720,8 +735,21 @@ void vtkMgx3DInteractorStyle::OnLeftButtonUp ( )
 void vtkMgx3DInteractorStyle::OnRightButtonUp ( )
 {
 	// Arrêter un éventuel déclenchement d'interaction :
+	vtkRenderWindowInteractor*	rwi	= this->Interactor;
+	bool	doRender	= true;
+	if (0 != rwi)
+	{	// Ne rien afficher si absence de déplacement entre le début et la fin du clic :
+		int	pos [2];
+		rwi->GetEventPosition (pos);
+		if (0 == memcmp (pos, ButtonPressPosition, 2 * sizeof (int)))
+			doRender	= false;
+	}	// if (0 != rwi)
+	if ((false == doRender) && (0 != CurrentRenderer))
+		CurrentRenderer->DrawOff ( );
 	vtkUnifiedInteractorStyle::OnRightButtonUp ( );
-
+	if ((false == doRender) && (0 != CurrentRenderer))
+		CurrentRenderer->DrawOn ( );
+		
 	// Si le curseur n'a pas bougé depuis la pression sur le bouton, et que
 	// c'est paramétré tel que, on fait un picking :
 	if ((true == GetInteractiveSelectionActivated ( )) && (true == Resources::instance ( )._pickOnRightButtonUp.getValue ( )))
@@ -737,6 +765,25 @@ void vtkMgx3DInteractorStyle::OnRightButtonUp ( )
 		}
 	}	// if ((true == GetInteractiveSelectionActivated ( )) && ...
 }	// vtkMgx3DInteractorStyle::OnRightButtonUp
+
+
+void vtkMgx3DInteractorStyle::OnMiddleButtonUp ( )
+{
+	vtkRenderWindowInteractor*	rwi	= this->Interactor;
+	bool	doRender	= true;
+	if (0 != rwi)
+	{	// Ne rien afficher si absence de déplacement entre le début et la fin du clic :
+		int	pos [2];
+		rwi->GetEventPosition (pos);
+		if (0 == memcmp (pos, ButtonPressPosition, 2 * sizeof (int)))
+			doRender	= false;
+	}	// if (0 != rwi)
+	if ((false == doRender) && (0 != CurrentRenderer))
+		CurrentRenderer->DrawOff ( );
+	vtkUnifiedInteractorStyle::OnMiddleButtonUp ( );
+	if ((false == doRender) && (0 != CurrentRenderer))
+		CurrentRenderer->DrawOn ( );
+}	// vtkMgx3DInteractorStyle::OnMiddleButtonUp
 
 
 void vtkMgx3DInteractorStyle::SetSelectionManager (SelectionManagerIfc* mgr)

--- a/src/Utils/DisplayProperties.cpp
+++ b/src/Utils/DisplayProperties.cpp
@@ -8,6 +8,7 @@
  */
 /*----------------------------------------------------------------------------*/
 #include "Utils/DisplayProperties.h"
+#include "Utils/GraphicalEntityRepresentation.h"		// CP TO REMOVE ?
 #include "Utils/Common.h"
 
 #include <TkUtil/Exception.h>
@@ -188,9 +189,9 @@ void DisplayProperties::EntityView::entityDisplayed (bool displayed)
 
 
 unsigned short	DisplayProperties::_defaultFontFamily	= 0;
-unsigned short	DisplayProperties::_defaultFontSize	= 12;
-bool		DisplayProperties::_defaultFontBold	= false;
-bool		DisplayProperties::_defaultFontItalic	= false;
+unsigned short	DisplayProperties::_defaultFontSize		= 12;
+bool		DisplayProperties::_defaultFontBold			= false;
+bool		DisplayProperties::_defaultFontItalic		= false;
 
 
 DisplayProperties::DisplayProperties ( )
@@ -437,7 +438,15 @@ bool DisplayProperties::isDisplayed ( ) const
 void DisplayProperties::setDisplayed(bool disp)
 {
 	if (_displayed != disp)
+{
+	GraphicalEntityRepresentation*	ger	= static_cast<GraphicalEntityRepresentation*>(getGraphicalRepresentation ( ));
+	if (0 != ger)
+	{
+		Entity::setDisplayed (*(ger->getEntity ( )), disp);
+
+	}	// if (0 != ger)
 		notifyViews (disp);
+}
     _displayed = disp;
     // c'est la vue qui met à jour l'info, ou le GroupManager à la fin d'une commande [EB]
 }

--- a/src/Utils/Entity.cpp
+++ b/src/Utils/Entity.cpp
@@ -152,6 +152,13 @@ std::string FilterEntity::filterToFullObjectTypeName (FilterEntity::objectType o
 	INTERNAL_ERROR(exc, error, "FilterEntity::filterToFullObjectTypeName")
 	throw TkUtil::Exception (exc);
 }
+
+/*----------------------------------------------------------------------------*/
+size_t	Entity::displayedTopoVertexCount	= 0;
+size_t	Entity::displayedTopoEdgeCount		= 0;
+size_t	Entity::displayedTopoFaceCount		= 0;
+size_t	Entity::displayedTopoBlockCount		= 0;
+
 /*----------------------------------------------------------------------------*/
 std::string Entity::objectTypeToObjectTypeName (objectType t)
 {
@@ -355,6 +362,45 @@ Property* Entity::setProperties (Property* prop)
     return old;
 }
 
+/*----------------------------------------------------------------------------*/
+void Entity::setDisplayed (const Entity& entity, bool displayed)
+{
+	const int	added	= true == displayed ? 1 : -1;
+	switch (entity.getType ( ))
+	{
+		case Entity::TopoVertex	: displayedTopoVertexCount	+= added;	break;
+		case Entity::TopoEdge	:
+		case Entity::TopoCoEdge	: displayedTopoEdgeCount	+= added;	break;
+		case Entity::TopoFace	:
+		case Entity::TopoCoFace	: displayedTopoFaceCount	+= added;	break;
+		case Entity::TopoBlock	: displayedTopoBlockCount	+= added;	break;
+	}	// switch (entity.getType ( ))
+}
+
+/*----------------------------------------------------------------------------*/
+size_t Entity::getDisplayedTopoVertexCount ( )
+{
+	return displayedTopoVertexCount;
+}
+
+/*----------------------------------------------------------------------------*/
+size_t Entity::getDisplayedTopoEdgeCount ( )
+{
+	return displayedTopoEdgeCount;
+}
+
+/*----------------------------------------------------------------------------*/
+size_t Entity::getDisplayedTopoFaceCount ( )
+{
+	return displayedTopoFaceCount;
+}
+
+/*----------------------------------------------------------------------------*/
+size_t Entity::getDisplayedTopoBlockCount ( )
+{
+	return displayedTopoBlockCount;
+}
+	
 /*----------------------------------------------------------------------------*/
 std::string Entity::getName() const
 {

--- a/src/Utils/protected/Utils/Entity.h
+++ b/src/Utils/protected/Utils/Entity.h
@@ -205,6 +205,24 @@ public:
 
     /*------------------------------------------------------------------------*/
     /**
+     * Appelé par une DisplayProperty lorsqu'une entité devient affichée ou non
+     * affichée. Gère un compteur d'entités affichées par type à des fins 
+     * d'affichage type LOD.
+     */
+#ifndef SWIG
+    static void setDisplayed (const Entity& entity, bool displayed);
+#endif
+
+#ifndef SWIG
+	/** Les nombres de vertex, arêtes, faces et blocs affichés. */
+	static size_t	getDisplayedTopoVertexCount ( );
+	static size_t	getDisplayedTopoEdgeCount ( );
+	static size_t	getDisplayedTopoFaceCount ( );
+	static size_t	getDisplayedTopoBlockCount ( );
+#endif
+
+    /*------------------------------------------------------------------------*/
+    /**
      *  \return		Le nom est unique pour un type d'entité donné.
      *  Mais pas unique pour tous type confondus
      *  \see getUniqueName()
@@ -376,6 +394,11 @@ private :
 	/** Le gestionnaire de message */
 	TkUtil::LogOutputStream* m_log_stream;
 
+	/** Les nombres de vertex, arêtes, faces et blocs affichés. */
+	static size_t	displayedTopoVertexCount;
+	static size_t	displayedTopoEdgeCount;
+	static size_t	displayedTopoFaceCount;
+	static size_t	displayedTopoBlockCount;
 };
 
 Entity::objectType typesToType (FilterEntity::objectType types);

--- a/src/etc/magix3d.xml
+++ b/src/etc/magix3d.xml
@@ -166,6 +166,30 @@
             <green>1.000000e+00</green>
             <blue>1.000000e+00</blue>
           </element>
+          <element name="topoVertexLodNumberThreshold" type="unsignedLong">
+          <annotation>
+            <documentation>Nombre maximum de vertex topologiques à afficher lors d'interactions.</documentation>
+          </annotation>
+          <value>250</value>
+        </element>
+        <element name="topoEdgeLodNumberThreshold" type="unsignedLong">
+          <annotation>
+            <documentation>Nombre maximum d'arêtes topologiques à afficher lors d'interactions.</documentation>
+          </annotation>
+          <value>250</value>
+        </element>
+        <element name="topoFaceLodNumberThreshold" type="unsignedLong">
+          <annotation>
+            <documentation>Nombre maximum de faces topologiques à afficher lors d'interactions.</documentation>
+          </annotation>
+          <value>250</value>
+        </element>
+        <element name="topoBlockLodNumberThreshold" type="unsignedLong">
+          <annotation>
+            <documentation>Nombre maximum de blocs topologiques à afficher lors d'interactions.</documentation>
+          </annotation>
+          <value>250</value>
+        </element>
         </Section>
         <Section name="meshEntities" type="container">
           <element name="destroyOnHide" type="boolean">
@@ -175,6 +199,18 @@
             <value>true</value>
           </element>
         </Section>
+        <element name="lodPointSize" type="unsignedLong">
+          <annotation>
+            <documentation>Taille des points/noeuds/vertex lors des interactions.</documentation>
+          </annotation>
+          <value>1</value>
+        </element>
+        <element name="lodLineWidth" type="unsignedLong">
+          <annotation>
+            <documentation>Epaisseur des lignes/arêtes lors des interactions.</documentation>
+          </annotation>
+          <value>1</value>
+        </element>
         <element name="fontFamily" type="string">
           <annotation>
             <documentation>Police de caractères utilisée pour les affichages graphiques. Valeurs possibles : Arial, Times, Courier.</documentation>


### PR DESCRIPTION
…ns. Each entity being displayed by an actor, a "LOD Magix3D" mode is created by assigning each actor a random number between 0 and 100. For each type of topological entity, a threshold from which we switch to "LOD Magix3D" mode is set in configuration: from this number, a number of entities at most equal to this threshold is displayed during interactions. An artifact remains suspended: when left-clicking - without movement - with or without selection - we switch the click time to LOD mode => deactivate this display in the absence of movement.