### PR TITLE
Issue 220 block boundingbox

### DIFF
--- a/src/Core/Internal/EntitiesHelper.cpp
+++ b/src/Core/Internal/EntitiesHelper.cpp
@@ -646,7 +646,7 @@ double EntitiesHelper::angle(const Utils::Entity* cec, const Utils::Entity* ce1,
 bool EntitiesHelper::getBounds (const std::vector<Utils::Entity*>& entities, double bounds [6])
 {
 	bounds [0]	= bounds [2]	= bounds [4]	= std::numeric_limits<double>::max();
-	bounds [1]	= bounds [3]	= bounds [5]	= std::numeric_limits<double>::min();
+	bounds [1]	= bounds [3]	= bounds [5]	= std::numeric_limits<double>::lowest();
 	if (true == entities.empty ( ))
 		return false;
 

--- a/test_link/test_free_bounded_topo.py
+++ b/test_link/test_free_bounded_topo.py
@@ -1,0 +1,16 @@
+import pyMagix3D as Mgx3D
+import pytest
+
+def test_freeboundedtopo():
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    gm = ctx.getGeomManager ()
+    tm = ctx.getTopoManager ()
+
+    gm.newVertex(Mgx3D.Point(-1.8, -.7, 1.2))
+    gm.newVertex(Mgx3D.Point(-.7, .45, -.1))
+    tm.newFreeBoundedTopoInGroup ("aaa", 3, ["Pt0000","Pt0001"])
+    c = tm.getCoord("Som0007")
+    assert c.getX() == -0.6999999
+    assert c.getY() ==  0.4500001
+    assert c.getZ() ==  1.2000001


### PR DESCRIPTION
The creation of a topological block based on the bounding box of a list of entities passed as parameter (`ctx.getTopoManager().newFreeBoundedTopoInGroup`) could produce a block with wrong coordinates, due to a faulty bounding box computation.