### PR TITLE
issue#162 topo is no longer created by default

### DIFF
--- a/src/QtComponents/QtBoxOperationAction.cpp
+++ b/src/QtComponents/QtBoxOperationAction.cpp
@@ -116,7 +116,7 @@ QtBoxOperationPanel::QtBoxOperationPanel (
 	groupBox->setLayout (vlayout);
 	const int	defaultEdgesNum	= mainWindow.getContext( ).getTopoManager( ).getDefaultNbMeshingEdges( );
 	_topologyPanel	= new QtTopologyPanel (
-		groupBox, mainWindow, true, false, 3, QtTopologyPanel::STRUCTURED_TOPOLOGY, QtTopologyPanel::CARTESIAN, defaultEdgesNum, defaultEdgesNum, defaultEdgesNum, true, true);
+		groupBox, mainWindow, false, false, 3, QtTopologyPanel::STRUCTURED_TOPOLOGY, QtTopologyPanel::CARTESIAN, defaultEdgesNum, defaultEdgesNum, defaultEdgesNum, true, true);
 	_topologyPanel->enableTopologyType (QtTopologyPanel::OGRID_BLOCKS, false);
 	_topologyPanel->enableTopologyType (QtTopologyPanel::STRUCTURED_FREE_TOPOLOGY, false);
 	_topologyPanel->enableTopologyType (QtTopologyPanel::INSERTION_TOPOLOGY, false);

--- a/src/QtComponents/QtConeOperationAction.cpp
+++ b/src/QtComponents/QtConeOperationAction.cpp
@@ -194,7 +194,7 @@ QtConeOperationPanel::QtConeOperationPanel (
 	const int	defaultEdgesNum	=
 		mainWindow.getContext( ).getTopoManager( ).getDefaultNbMeshingEdges( );
 	_topologyPanel	= new QtTopologyPanel (
-			groupCone, mainWindow, true, false, 3,
+			groupCone, mainWindow, false, false, 3,
 			QtTopologyPanel::OGRID_BLOCKS, QtTopologyPanel::OGRID,
 			defaultEdgesNum, defaultEdgesNum, defaultEdgesNum, true, true);
 	_topologyPanel->enableTopologyType (

--- a/src/QtComponents/QtCylinderOperationAction.cpp
+++ b/src/QtComponents/QtCylinderOperationAction.cpp
@@ -209,7 +209,7 @@ QtCylinderOperationPanel::QtCylinderOperationPanel (
 	const int	defaultEdgesNum	=
 		mainWindow.getContext( ).getTopoManager( ).getDefaultNbMeshingEdges( );
 	_topologyPanel	= new QtTopologyPanel (
-			groupBox, mainWindow, true, false, 3,
+			groupBox, mainWindow, false, false, 3,
 			QtTopologyPanel::OGRID_BLOCKS, QtTopologyPanel::OGRID,
 			defaultEdgesNum, defaultEdgesNum, defaultEdgesNum, true, true);
 	_topologyPanel->enableTopologyType (

--- a/src/QtComponents/QtSphereOperationAction.cpp
+++ b/src/QtComponents/QtSphereOperationAction.cpp
@@ -194,7 +194,7 @@ QtSphereOperationPanel::QtSphereOperationPanel (
 	const int	defaultEdgesNum	=
 		mainWindow.getContext( ).getTopoManager( ).getDefaultNbMeshingEdges( );
 	_topologyPanel	= new QtTopologyPanel (
-			groupBox, mainWindow, true, false, 3, QtTopologyPanel::OGRID_BLOCKS,
+			groupBox, mainWindow, false, false, 3, QtTopologyPanel::OGRID_BLOCKS,
 			QtTopologyPanel::OGRID,
 			-1 /* Pas d'axe 1 */, defaultEdgesNum, defaultEdgesNum, true, true);
 	_topologyPanel->enableTopologyType (

--- a/src/QtComponents/QtSpherePartOperationAction.cpp
+++ b/src/QtComponents/QtSpherePartOperationAction.cpp
@@ -207,7 +207,7 @@ QtSpherePartOperationPanel::QtSpherePartOperationPanel (
 	const int	defaultEdgesNum	=
 		mainWindow.getContext( ).getTopoManager( ).getDefaultNbMeshingEdges( );
 	_topologyPanel	= new QtTopologyPanel (
-			groupBox, mainWindow, true, false, 3, QtTopologyPanel::STRUCTURED_TOPOLOGY,
+			groupBox, mainWindow, false, false, 3, QtTopologyPanel::STRUCTURED_TOPOLOGY,
 			QtTopologyPanel::CARTESIAN,
 			defaultEdgesNum, defaultEdgesNum, defaultEdgesNum, true, true);
 	_topologyPanel->enableTopologyType (


### PR DESCRIPTION
When creatig geom entities, like boxes, spheres, ... a templated blocking can optionally be created; the default was previously `true`, it is now `false`.