### PR TITLE
Materials colors dev

### DIFF
--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library (Core ${CPP_SOURCES} ${HEADERS})
 
 set (CORE_OPTIONAL_LIBRARIES_LIST)
 
-find_package (PrefsCore REQUIRED)
+find_package (PrefsXerces REQUIRED)
 find_package (PythonUtil REQUIRED)
 find_package (GQGMDS REQUIRED)
 #find_package (MachineTypes REQUIRED)
@@ -87,7 +87,7 @@ target_include_directories (Core PUBLIC ${GMDS_INCLUDE_DIR})
 target_include_directories (Core PUBLIC ${OpenCASCADE_INCLUDE_DIR})
 target_link_libraries (Core PUBLIC ${OpenCASCADE_FoundationClasses_LIBRARIES} ${OpenCASCADE_ModelingAlgorithms_LIBRARIES} ${OpenCASCADE_DataExchange_LIBRARIES})
 
-target_link_libraries (Core PUBLIC GQGMDS::GQGMDS Lima::Lima Utils PrefsCore::PrefsCore PythonUtil::PythonUtil)
+target_link_libraries (Core PUBLIC GQGMDS::GQGMDS Lima::Lima Utils PrefsXerces::PrefsXerces PythonUtil::PythonUtil)
 if (USE_TRITON)
 	target_link_libraries (Core PUBLIC Triton2)
 endif()

--- a/src/Core/Geom/Curve.cpp
+++ b/src/Core/Geom/Curve.cpp
@@ -9,6 +9,7 @@
 #include "Geom/OCCHelper.h"
 #include "Geom/GeomProjectImplementation.h"
 #include "Group/Group1D.h"
+#include "Internal/EntitiesHelper.h"
 /*----------------------------------------------------------------------------*/
 #include <TkUtil/MemoryError.h>
 /*----------------------------------------------------------------------------*/
@@ -640,6 +641,16 @@ void Curve::add(Group::Group1D* grp)
 {
     //std::cout<<"Curve::add("<<grp->getName()<<") à "<<getName()<<std::endl;
     m_groups.push_back(grp);
+    
+    TkUtil::Color	color (0, 0, 0);
+    std::vector<Group::GroupEntity*>	groups	= Internal::groupsFromTypedGroups (m_groups);
+    if (true == getContext ( ).getGroupColor (groups, color))
+    {
+		getDisplayProperties ( ).setCloudColor (color);
+		getDisplayProperties ( ).setWireColor (color);
+		getDisplayProperties ( ).setSurfacicColor (color);
+		getDisplayProperties ( ).setFontColor (color);
+	}	// if (true == getContext ( ).getGroupColor (groups, color))
 }
 /*----------------------------------------------------------------------------*/
 void Curve::remove(Group::Group1D* grp)

--- a/src/Core/Geom/Surface_Geom.cpp
+++ b/src/Core/Geom/Surface_Geom.cpp
@@ -7,6 +7,7 @@
 #include "Geom/EntityFactory.h"
 #include "Geom/GeomProjectImplementation.h"
 #include "Group/Group2D.h"
+#include "Internal/EntitiesHelper.h"
 /*----------------------------------------------------------------------------*/
 #include <TkUtil/MemoryError.h>
 /*----------------------------------------------------------------------------*/
@@ -226,6 +227,16 @@ bool Surface::isA(const std::string& name)
 void Surface::add(Group::Group2D* grp)
 {
     m_groups.push_back(grp);
+    
+    TkUtil::Color	color (0, 0, 0);
+    std::vector<Group::GroupEntity*>	groups	= Internal::groupsFromTypedGroups (m_groups);
+    if (true == getContext ( ).getGroupColor (groups, color))
+    {
+		getDisplayProperties ( ).setCloudColor (color);
+		getDisplayProperties ( ).setWireColor (color);
+		getDisplayProperties ( ).setSurfacicColor (color);
+		getDisplayProperties ( ).setFontColor (color);
+	}	// if (true == getContext ( ).getGroupColor (groups, color))
 }
 /*----------------------------------------------------------------------------*/
 void Surface::remove(Group::Group2D* grp)

--- a/src/Core/Geom/Vertex_Geom.cpp
+++ b/src/Core/Geom/Vertex_Geom.cpp
@@ -5,6 +5,7 @@
 #include "Geom/OCCHelper.h"
 #include "Group/Group0D.h"
 #include "Internal/Context.h"
+#include "Internal/EntitiesHelper.h"
 /*----------------------------------------------------------------------------*/
 #include <TopoDS_Vertex.hxx>
 #include <TopoDS_Shape.hxx>
@@ -139,6 +140,16 @@ TkUtil::UTF8String& operator<<(TkUtil::UTF8String& str, const Vertex& v)
 void Vertex::add(Group::Group0D* grp)
 {
     m_groups.push_back(grp);
+    
+    TkUtil::Color	color (0, 0, 0);
+    std::vector<Group::GroupEntity*>	groups	= Internal::groupsFromTypedGroups (m_groups);
+    if (true == getContext ( ).getGroupColor (groups, color))
+    {
+		getDisplayProperties ( ).setCloudColor (color);
+		getDisplayProperties ( ).setWireColor (color);
+		getDisplayProperties ( ).setSurfacicColor (color);
+		getDisplayProperties ( ).setFontColor (color);
+	}	// if (true == getContext ( ).getGroupColor (groups, color))
 }
 /*----------------------------------------------------------------------------*/
 void Vertex::remove(Group::Group0D* grp)

--- a/src/Core/Geom/Volume_Geom.cpp
+++ b/src/Core/Geom/Volume_Geom.cpp
@@ -6,6 +6,7 @@
 #include "Geom/OCCHelper.h"
 #include "Group/Group3D.h"
 #include "Internal/Context.h"
+#include "Internal/EntitiesHelper.h"
 /*----------------------------------------------------------------------------*/
 #include <TkUtil/Exception.h>
 #include <TkUtil/MemoryError.h>
@@ -115,6 +116,16 @@ bool Volume::isA(const std::string& name)
 void Volume::add(Group::Group3D* grp)
 {
     m_groups.push_back(grp);
+    
+    TkUtil::Color	color (0, 0, 0);
+    std::vector<Group::GroupEntity*>	groups	= Internal::groupsFromTypedGroups (m_groups);
+    if (true == getContext ( ).getGroupColor (groups, color))
+    {
+		getDisplayProperties ( ).setCloudColor (color);
+		getDisplayProperties ( ).setWireColor (color);
+		getDisplayProperties ( ).setSurfacicColor (color);
+		getDisplayProperties ( ).setFontColor (color);
+	}	// if (true == getContext ( ).getGroupColor (groups, color))
 }
 /*----------------------------------------------------------------------------*/
 void Volume::remove(Group::Group3D* grp)

--- a/src/Core/Group/GroupHelperForCommand.cpp
+++ b/src/Core/Group/GroupHelperForCommand.cpp
@@ -17,6 +17,7 @@ addToGroup(const std::string group_name, Geom::Volume* v)
 {
 	Group3D* grp = m_group_manager.getNewGroup3D(group_name, &m_info_command);
     addEntityToGroup(grp, v);
+    m_info_command.addGeomInfoEntity (v, Internal::InfoCommand::DISPMODIFIED);
     return grp;
 }
 /*----------------------------------------------------------------------------*/
@@ -25,6 +26,7 @@ addToGroup(const std::string group_name, Geom::Surface* s)
 {
 	Group2D* grp = m_group_manager.getNewGroup2D(group_name, &m_info_command);
     addEntityToGroup(grp, s);
+    m_info_command.addGeomInfoEntity (s, Internal::InfoCommand::DISPMODIFIED);
     return grp;
 }
 /*----------------------------------------------------------------------------*/
@@ -33,6 +35,7 @@ addToGroup(const std::string group_name, Geom::Curve* c)
 {
 	Group1D* grp = m_group_manager.getNewGroup1D(group_name, &m_info_command);
     addEntityToGroup(grp, c);
+    m_info_command.addGeomInfoEntity (c, Internal::InfoCommand::DISPMODIFIED);
     return grp;
 }
 /*----------------------------------------------------------------------------*/
@@ -41,6 +44,7 @@ addToGroup(const std::string group_name, Geom::Vertex* v)
 {
 	Group0D* grp = m_group_manager.getNewGroup0D(group_name, &m_info_command);
     addEntityToGroup(grp, v);
+    m_info_command.addGeomInfoEntity (v, Internal::InfoCommand::DISPMODIFIED);
     return grp;
 }
 /*----------------------------------------------------------------------------*/

--- a/src/Core/protected/Internal/Context.h
+++ b/src/Core/protected/Internal/Context.h
@@ -442,6 +442,25 @@ public:
 	* (<I>true == getDisplayProperties ( ).isDisplayable</I>.
 	*/
 	void newGraphicalRepresentation(Utils::Entity& entity);
+
+	/**
+	 * Recherche une couleur en configuration pour une entité. Une entité pouvant appartenir à plusieurs
+	 * groupes c'est ici la liste des groupes qui est transmise en argument.
+	 * \param	Groupes dont on veut récupérer une éventuelle couleur définie en configuration. 
+	 *			La première couleur trouvée en configuration est retenue.
+	 * \param	En retour, la première couleur trouvée en configuration, s'il y en a une.
+	 * \return	true si une couleur est trouvée, false dans le cas contraire.
+	 * \see		loadGroupsColors
+	 */
+	 bool getGroupColor (const std::vector<Group::GroupEntity*>& groups, TkUtil::Color& color);
+
+	/**
+	 * Recherche une couleur en configuration pour une entité.
+	 * \param		Nom du groupe dont on recherche une couleur.
+	 * \return		La couleur associé au groupe dont le nom est transmis en argument.
+	 * \exception	Une exception est levée si la couleur n'est pas trouvée en configuration.
+	 */
+	 TkUtil::Color getGroupColor (const std::string& name);
 #endif
 
     /** Passage en mode apperçu ou non. En mode apperçu les couleurs fournies
@@ -603,6 +622,12 @@ public:
 	std::string createName (const std::string& base) const;
 
 private:
+  
+    /**
+     * Le chargement optionnel des fichiers table groupe -> couleur.
+     */
+    static void loadGroupsColors (const Preferences::Section& section);
+
 	/** Nom unique de l'instance. */
 	std::string m_name;
 
@@ -676,6 +701,9 @@ private:
 
     /** Le jeu de caractères utilisé par la sortie standard. */
     static TkUtil::Charset		m_outCharset;
+
+	/** La table groupe -> couleur.  */
+	static std::map<std::string, TkUtil::Color>	m_groups_colors;
 
 	/** booléen positionné à vrai seulement lorsque la sessione est terminée
 	 * (destruction du context)

--- a/src/Core/protected/Internal/EntitiesHelper.h
+++ b/src/Core/protected/Internal/EntitiesHelper.h
@@ -173,6 +173,32 @@ template < typename E > inline std::vector< Mgx3D::Utils::Entity* > entitiesFrom
 }	// entitiesFromTypedEntities
 
 /**
+ * \return		Une liste de groupes issue d'une liste de groupes typés.
+ */
+template < typename G > inline std::vector< Mgx3D::Group::GroupEntity* > groupsFromTypedGroups (
+								const std::vector< G* >& typedGroups, bool strict = true)
+{
+	std::vector< Mgx3D::Group::GroupEntity* >	groups;
+
+	for (typename std::vector< G* >::const_iterator	it	= typedGroups.begin ( );
+		 typedGroups.end ( ) != it; it++)
+	{
+		Mgx3D::Group::GroupEntity*	group	= dynamic_cast<Mgx3D::Group::GroupEntity*>(*it);
+		if ((0 == group) && (true == strict))
+		{
+			TkUtil::UTF8String	message (TkUtil::Charset::UTF_8);
+			message << "Erreur, le groupe " << (*it)->getName ( )
+			        << " n'est pas du bon type.";
+			INTERNAL_ERROR (exc, message, "groupsFromTypedGroups")
+			throw exc;
+		}	// if ((0 == group) && (true == strict))
+		groups.push_back (group);
+	}
+
+	return groups;
+}	// groupsFromTypedGroups
+
+/**
  * \return		La différence entre les 2 listes d'entités reçues en premiers arguments.
  * \param		before et after représentent la même liste d'entités avant et après un évènement, par exemple l'exécution d'une commande
  * \param		En sortie added recevra les entités présentes dans after mais pas dans before


### PR DESCRIPTION
Optional definition of display colours for geometric entities according to the name of their group of belonging.

To try it, run Magix3D as following :

Magix3D --groupsColors rgb.xml

where rgb.xml contains :

<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<GroupProperties XMLLoader_version="0.3.0">
  <Section name="Groups" type="container">
	  
    <Section name="ROUGE" type="container">
      <element name="color" type="color">
        <red>1.</red>
        <green>0.</green>
        <blue>0.</blue>
      </element>
    </Section>

    <Section name="VERT" type="container">
      <element name="color" type="color">
        <red>0.</red>
        <green>1.</green>
        <blue>0.</blue>
      </element>
    </Section>

    <Section name="BLEU" type="container">
      <element name="color" type="color">
        <red>0.</red>
        <green>0.</green>
        <blue>1.</blue>
      </element>
    </Section>
    
  </Section>
  
</GroupProperties>

Here are a few Python commands to execute in the console to illustrate the point :

cmd = gm.newBox (Mgx3D.Point (0, 0, 0), Mgx3D.Point (1, 1, 1), "ROUGE")
gm.addToGroup (cmd.getSurfaces ( ), 2, "ROUGE")
gm.addToGroup (cmd.getCurves ( ), 1, "ROUGE")
gm.addToGroup (cmd.getVertices ( ), 0, "ROUGE")
cmd = gm.newBox (Mgx3D.Point (1, 0, 0), Mgx3D.Point (2, 1, 1), "VERT")
gm.addToGroup (cmd.getSurfaces ( ), 2, "VERT")
gm.addToGroup (cmd.getCurves ( ), 1, "VERT")
gm.addToGroup (cmd.getVertices ( ), 0, "VERT")
cmd = gm.newBox (Mgx3D.Point (2, 0, 0), Mgx3D.Point (3, 1, 1), "BLEU")
gm.addToGroup (cmd.getSurfaces ( ), 2, "BLEU")
gm.addToGroup (cmd.getCurves ( ), 1, "BLEU")
gm.addToGroup (cmd.getVertices ( ), 0, "BLEU")



