### PR TITLE
Context::getGroupColor no longer throws an exception if no color is a…

### DIFF
--- a/src/Core/Internal/Context.cpp
+++ b/src/Core/Internal/Context.cpp
@@ -1422,36 +1422,14 @@ void Context::newGraphicalRepresentation (Utils::Entity& entity)
 bool Context::getGroupColor (const std::vector<Group::GroupEntity*>& groups, TkUtil::Color& color)
 {
 	for (std::vector<Group::GroupEntity*>::const_iterator itg = groups.begin ( ); groups.end ( ) != itg; itg++)
-	{
-		try
+	{	
+		const std::map<std::string, TkUtil::Color>::iterator it	= m_groups_colors.find ((*itg)->getName ( ));
+		if (m_groups_colors.end ( ) != it)
 		{
-			if (true == getGroupColor ((*itg)->getName ( ), color, false))
-				return true;
+			color	= it->second;
+			return true;
 		}
-		catch (...)
-		{
-		}
-	}	// for (std::vector<Group::GroupEntity*>::const_iterator itg = groups.begin ( ); groups.end ( ) != itg; itg++)
-	
-	return false;
-}	// Context::getGroupColor
-/*----------------------------------------------------------------------------*/
-bool Context::getGroupColor (const std::string& name, TkUtil::Color& color, bool raise)
-{
-	const std::map<std::string, TkUtil::Color>::iterator it	= m_groups_colors.find (name);
-	if (m_groups_colors.end ( ) != it)
-	{
-		color	= it->second;
-		return true;
-	}
-
-	if (true == raise)
-	{
-		TkUtil::UTF8String	message;
-		message << "Context::groupColor. Couleur pour le groupe de données \"" << name << "\" non recensée.";
-		throw TkUtil::Exception (message);
-	}
-	
+	}	
 	return false;
 }	// Context::getGroupColor
 /*----------------------------------------------------------------------------*/

--- a/src/Core/Internal/Context.cpp
+++ b/src/Core/Internal/Context.cpp
@@ -1425,8 +1425,8 @@ bool Context::getGroupColor (const std::vector<Group::GroupEntity*>& groups, TkU
 	{
 		try
 		{
-			color	= getGroupColor ((*itg)->getName ( ));
-			return true;
+			if (true == getGroupColor ((*itg)->getName ( ), color, false))
+				return true;
 		}
 		catch (...)
 		{
@@ -1436,15 +1436,23 @@ bool Context::getGroupColor (const std::vector<Group::GroupEntity*>& groups, TkU
 	return false;
 }	// Context::getGroupColor
 /*----------------------------------------------------------------------------*/
-TkUtil::Color Context::getGroupColor (const std::string& name)
+bool Context::getGroupColor (const std::string& name, TkUtil::Color& color, bool raise)
 {
 	const std::map<std::string, TkUtil::Color>::iterator it	= m_groups_colors.find (name);
 	if (m_groups_colors.end ( ) != it)
-		return it->second;
+	{
+		color	= it->second;
+		return true;
+	}
 
-	TkUtil::UTF8String	message;
-	message << "Context::groupColor. Couleur pour le groupe de données \"" << name << "\" non recensée.";
-	throw TkUtil::Exception (message);
+	if (true == raise)
+	{
+		TkUtil::UTF8String	message;
+		message << "Context::groupColor. Couleur pour le groupe de données \"" << name << "\" non recensée.";
+		throw TkUtil::Exception (message);
+	}
+	
+	return false;
 }	// Context::getGroupColor
 /*----------------------------------------------------------------------------*/
 void Context::undo()

--- a/src/Core/protected/Internal/Context.h
+++ b/src/Core/protected/Internal/Context.h
@@ -454,17 +454,6 @@ public:
 	 * \see		loadGroupsColors
 	 */
 	 bool getGroupColor (const std::vector<Group::GroupEntity*>& groups, TkUtil::Color& color);
-
-	/**
-	 * Recherche une couleur en configuration pour une entité.
-	 * \param		Nom du groupe dont on recherche une couleur.
-	 * \param		En retour, la couleur associé au groupe.
-	 * \param		true s'il faut lever une exception si la couleur n'est pas trouvée
-	 * \return		true si la couleur est trouvée, false dansle cas contraire
-	 * \exception	Une exception est levée si la couleur n'est pas trouvée en configuration et
-	 * 				si raise vaut true.
-	 */
-	 bool getGroupColor (const std::string& name, TkUtil::Color& color, bool raise = true);
 #endif
 
     /** Passage en mode apperçu ou non. En mode apperçu les couleurs fournies

--- a/src/Core/protected/Internal/Context.h
+++ b/src/Core/protected/Internal/Context.h
@@ -458,10 +458,13 @@ public:
 	/**
 	 * Recherche une couleur en configuration pour une entité.
 	 * \param		Nom du groupe dont on recherche une couleur.
-	 * \return		La couleur associé au groupe dont le nom est transmis en argument.
-	 * \exception	Une exception est levée si la couleur n'est pas trouvée en configuration.
+	 * \param		En retour, la couleur associé au groupe.
+	 * \param		true s'il faut lever une exception si la couleur n'est pas trouvée
+	 * \return		true si la couleur est trouvée, false dansle cas contraire
+	 * \exception	Une exception est levée si la couleur n'est pas trouvée en configuration et
+	 * 				si raise vaut true.
 	 */
-	 TkUtil::Color getGroupColor (const std::string& name);
+	 bool getGroupColor (const std::string& name, TkUtil::Color& color, bool raise = true);
 #endif
 
     /** Passage en mode apperçu ou non. En mode apperçu les couleurs fournies


### PR DESCRIPTION
…ssigned to the group passed as an argument, in order to facilitate software debugging. This function is called indirectly with each preview request and is therefore likely to throw exceptions very frequently, unnecessarily interrupting the debugging session.