### PR TITLE
Issue 242: remove nodes positions update from destructor in surfacic smoother

### DIFF
--- a/src/Core/Smoothing/MesquiteMeshAdapter.cpp
+++ b/src/Core/Smoothing/MesquiteMeshAdapter.cpp
@@ -22,8 +22,6 @@ namespace Mgx3D {
 /*----------------------------------------------------------------------------*/
 namespace Mesh {
 /*----------------------------------------------------------------------------*/
-//#define _DEBUG2
-/*----------------------------------------------------------------------------*/
 MesquiteMeshAdapter::
 MesquiteMeshAdapter(std::vector<gmds::Face>& gmdsPolygones,
 			std::vector<gmds::Node >& gmdsNodes,
@@ -32,16 +30,10 @@ MesquiteMeshAdapter(std::vector<gmds::Face>& gmdsPolygones,
 			uint maskFixed)
 : m_gmdsNodes(gmdsNodes)
 {
-#ifdef _DEBUG2
-	std::cout << "MesquiteMeshAdapter::MesquiteMeshAdapter\n";
-#endif
 	Mesquite::MsqError err;
 
 	// Tous les noeuds sont pris
 	int vertexCount = gmdsNodes.size();
-#ifdef _DEBUG2
-	std::cout << "vertexCount = "<<vertexCount<<std::endl;
-#endif
 
 	// Remplissage des structures pour Mesquite
 	myMesh->allocate_vertices (vertexCount, err);
@@ -52,9 +44,6 @@ MesquiteMeshAdapter(std::vector<gmds::Face>& gmdsPolygones,
 
 	for (uint i=0; i<vertexCount; i++){
 		gmds::Node nd = m_gmdsNodes[i];
-#ifdef _DEBUG2
-		std::cout << " i "<<i<<", "<<nd<<" fixé ? "<<(filtre_nodes[nd.id()] == maskFixed?"vrai":"faux")<<std::endl;
-#endif
 		num_insurf[nd.id()] = i;
 		myMesh->reset_vertex (i,
 				Mesquite::Vector3D (nd.X(), nd.Y(), nd.Z()),
@@ -96,41 +85,30 @@ MesquiteMeshAdapter(std::vector<gmds::Face>& gmdsPolygones,
 			throw TkUtil::Exception (TkUtil::UTF8String ("MesquiteMeshAdapter avec type d'élément non prévu", TkUtil::Charset::UTF_8));
 			break;
 		}
-#ifdef _DEBUG2
-		std::cout << " reset_element ("<<elementCount;
-		for (uint i=0; i<vertices.size(); i++)
-			std::cout <<", "<<vertices[i];
-		std::cout <<")"<<std::endl;
-#endif
 		myMesh->reset_element (elementCount, vertices, elem_type, err);
 		elementCount++;
 	}
 	MSQ_CHKERR (err);
-#ifdef _DEBUG2
-	std::cout << "elementCount = "<<elementCount<<std::endl;
-#endif
 
 }
 /*----------------------------------------------------------------------------*/
 MesquiteMeshAdapter::~MesquiteMeshAdapter()
 {
-#ifdef _DEBUG2
-    std::cout << "MesquiteMeshAdapter::~MesquiteMeshAdapter\n";
-#endif
-    MESQUITE_NS::MsqError err;
+}
+/*----------------------------------------------------------------------------*/
+void MesquiteMeshAdapter::updateNodePositions()
+{
+	MESQUITE_NS::MsqError err;
 
-    for (size_t i = 0; i < m_gmdsNodes.size(); ++i){
-    	gmds::Node nd = m_gmdsNodes[i];
-
-	    MESQUITE_NS::Vector3D coord = myMesh->get_vertex_coords(i, err);
-	    nd.setX(coord[0]);
-	    nd.setY(coord[1]);
-	    nd.setZ(coord[2]);
-#ifdef _DEBUG2
-	    std::cout << " i "<<i<<", "<<nd<<std::endl;
-#endif
-    }
-    MSQ_CHKERR (err);
+	for (size_t i = 0; i < m_gmdsNodes.size(); ++i)
+	{
+		gmds::Node nd = m_gmdsNodes[i];
+		MESQUITE_NS::Vector3D coord = myMesh->get_vertex_coords(i, err);
+		nd.setX(coord[0]);
+		nd.setY(coord[1]);
+		nd.setZ(coord[2]);
+	}
+	MSQ_CHKERR (err);
 }
 /*----------------------------------------------------------------------------*/
 } // end namespace Mesh

--- a/src/Core/Smoothing/MesquiteMeshAdapter.cpp
+++ b/src/Core/Smoothing/MesquiteMeshAdapter.cpp
@@ -96,7 +96,7 @@ MesquiteMeshAdapter::~MesquiteMeshAdapter()
 {
 }
 /*----------------------------------------------------------------------------*/
-void MesquiteMeshAdapter::updateNodePositions()
+void MesquiteMeshAdapter::updateNodesPositions()
 {
 	MESQUITE_NS::MsqError err;
 

--- a/src/Core/Smoothing/SurfacicSmoothing.cpp
+++ b/src/Core/Smoothing/SurfacicSmoothing.cpp
@@ -155,6 +155,8 @@ applyModification(std::vector<gmds::Node >& gmdsNodes,
 			algo.loop_over_mesh (&myAssoc, &dummySettings, err);
 			MSQ_CHKERR(err);
 
+			mesh->updateNodesPositions();
+
 		} else {
 
 			MESQUITE_NS::QualityMetric* qual =0;
@@ -233,6 +235,8 @@ applyModification(std::vector<gmds::Node >& gmdsNodes,
 
 			delete pass1;
 			delete qual;
+
+			mesh->updateNodesPositions();
 		} // end else if (m_methodeLissage == surfacicOrthogonalSmoothingElliptic)
 	} // end if (m_nbIterations)
 
@@ -254,6 +258,7 @@ applyModification(std::vector<gmds::Node >& gmdsNodes,
 		}
 		MSQ_CHKERR (err);
 
+		mesh->updateNodesPositions();
 	}
 
 	delete mesh;

--- a/src/Core/protected/Smoothing/MesquiteMeshAdapter.h
+++ b/src/Core/protected/Smoothing/MesquiteMeshAdapter.h
@@ -47,7 +47,7 @@ public:
 	/*------------------------------------------------------------------------*/
 	/** \brief  Update node positions after smoothing
 	 */
-	void updateNodePositions();
+	void updateNodesPositions();
 
 private:
 	/// copie de la liste des noeuds concernés pour les modifier

--- a/src/Core/protected/Smoothing/MesquiteMeshAdapter.h
+++ b/src/Core/protected/Smoothing/MesquiteMeshAdapter.h
@@ -39,8 +39,15 @@ public:
 			std::map<gmds::TCellID, bool>& isPolyInverted,
 			uint maskFixed);
 
-	/// retour de Mesquite vers Gmds (modif des positions des noeuds)
+	/*------------------------------------------------------------------------*/
+	/** \brief   Destructor
+	 */
 	virtual ~MesquiteMeshAdapter();
+
+	/*------------------------------------------------------------------------*/
+	/** \brief  Update node positions after smoothing
+	 */
+	void updateNodePositions();
 
 private:
 	/// copie de la liste des noeuds concernés pour les modifier


### PR DESCRIPTION
This change aims to move the update of mesh nodes positions from MesquiteMeshAdapter class destructor, to a dedicated function. 
This change is necessary for code readability, and for adding new surfacic smoothers.

The tests pass, but we note that surfacic smoothers are not tested enough.