### PR TITLE
gitignore: changed cmake-build-debug to cmake-build-* pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode
 .idea
-cmake-build-debug
+cmake-build-*
 __pycache__
 build-linux-ubuntu*
 spack-build*


### PR DESCRIPTION
It is so that `cmake-build-release` is also ignored