### PR TITLE
display property: lineWidth is hardcoded to 1

### DIFF
--- a/src/QtComponents/RenderedEntityRepresentation.cpp
+++ b/src/QtComponents/RenderedEntityRepresentation.cpp
@@ -235,11 +235,11 @@ float RenderedEntityRepresentation::getPointSize (
 float RenderedEntityRepresentation::getLineWidth (
 									const Entity& entity, unsigned long mask)
 {
-	float lineWidth	= 1;
 	//const DisplayProperties&	properties	= entity.getDisplayProperties ( );
 	const DisplayProperties	properties	= getDisplayPropertiesAttributes ( );
 	const DisplayProperties::GraphicalRepresentation*	rep	=
 		entity.getDisplayProperties ( ).getGraphicalRepresentation ( );
+    float lineWidth	= properties.getLineWidth ( );
 
 	if ((0 != rep) && (true == rep->isSelected ( )))
 	{


### PR DESCRIPTION
The `lineWidth` display property is hardcoded to 1 and is not taken from the value set in https://github.com/LIHPC-Computational-Geometry/magix3d/blob/main/src/Core/Internal/Context.cpp