### PR TITLE
Issue-249

### DIFF
--- a/src/Core/Geom/GeomManager.cpp
+++ b/src/Core/Geom/GeomManager.cpp
@@ -2371,11 +2371,12 @@ newBSpline(Vertex* vtx1,
             new CommandNewBSpline(getContext(), vtx1, vp, vtx2, deg_min, deg_max, groupName);
     // trace dans le script
     TkUtil::UTF8String cmd (TkUtil::Charset::UTF_8);
-    cmd << getContextAlias ( ) << ".getGeomManager ( ).newBSpline (" ;
-    cmd << "\"" << vtx1->getName() << "\"," ;
+    cmd << getContextAlias ( ) << ".getGeomManager ( ).newBSpline (";
+    cmd << "\"" << vtx1->getName() << "\",";
     cmd << Internal::scriptablesToPythonList<Point> (vp) << ", ";
-    cmd << "\"" << vtx2->getName()<<"\","<<(short)deg_min<<", "<<(short)deg_max
-    		<<", \""<<groupName<<"\")";
+    cmd << "\"" << vtx2->getName() << "\",";
+    cmd << static_cast<short>(deg_min) << ", " << static_cast<short>(deg_max);
+    cmd << ", \"" << groupName << "\")";
     command->setScriptCommand(cmd);
 
     getCommandManager().addCommand(command, Utils::Command::DO);

--- a/src/Core/Geom/GeomManager.cpp
+++ b/src/Core/Geom/GeomManager.cpp
@@ -2371,8 +2371,10 @@ newBSpline(Vertex* vtx1,
             new CommandNewBSpline(getContext(), vtx1, vp, vtx2, deg_min, deg_max, groupName);
     // trace dans le script
     TkUtil::UTF8String cmd (TkUtil::Charset::UTF_8);
-    cmd << getContextAlias ( ) << ".getGeomManager ( ).newBSpline (" << Internal::scriptablesToPythonList<Point> (vp) << ", ";
-    cmd <<vtx2->getName()<<"\","<<(short)deg_min<<", "<<(short)deg_max
+    cmd << getContextAlias ( ) << ".getGeomManager ( ).newBSpline (" ;
+    cmd << "\"" << vtx1->getName() << "\"," ;
+    cmd << Internal::scriptablesToPythonList<Point> (vp) << ", ";
+    cmd << "\"" << vtx2->getName()<<"\","<<(short)deg_min<<", "<<(short)deg_max
     		<<", \""<<groupName<<"\")";
     command->setScriptCommand(cmd);
 


### PR DESCRIPTION

The following python consol commands:

```
ctx.getGeomManager().newVertex(Mgx3D.Point(1,0,0))
ctx.getGeomManager().newVertex(Mgx3D.Point(2,1,0))
ctx.getGeomManager().newBSpline("Pt0000", [Mgx3D.Point(1.2, 0.5, 0), Mgx3D.Point(1.9, 0.6, 0)], "Pt0001", 1, 2, "")
```

are registered under the minimal python script as:

```
# Création du sommet Pt0000
ctx.getGeomManager().newVertex (Mgx3D.Point(1, 0, 0))
# Création du sommet Pt0001
ctx.getGeomManager().newVertex (Mgx3D.Point(2, 1, 0))
# Création de la bspline Crb0000
ctx.getGeomManager ( ).newBSpline ([Mgx3D.Point(1.2, .5, 0),Mgx3D.Point(1.9, .6, 0)], Pt0001",1, 2, "")
```

Which contains two problems on the **newBSpline** line:
* First geometric point name "Pt0000" is missing
* First quotation mark of second point  "Pt0001" is missing


This PR proposes a fix for this issue.