### PR TITLE
issue_257: update python script command writing for beta law progress…

### DIFF
--- a/src/Core/Topo/EdgeMeshingPropertyBeta.cpp
+++ b/src/Core/Topo/EdgeMeshingPropertyBeta.cpp
@@ -141,10 +141,18 @@ getScriptCommand() const
 {
     TkUtil::UTF8String o (TkUtil::Charset::UTF_8);
     o << getMgx3DAlias() << ".EdgeMeshingPropertyBeta("
-      << (long)m_nb_edges <<","
+      << static_cast<long>(m_nb_edges) << ","
       << Utils::Math::MgxNumeric::userRepresentation(m_beta);
-    if (!getDirect())
-    	o << ", False";
+    if (m_initWithArm1)
+    {
+        o << (getDirect() ? std::string(", True") : std::string(", False"));
+        o << ", True"; // this is for m_initWithArm1
+        o << ", " << Utils::Math::MgxNumeric::userRepresentation(m_arm1);
+    }
+    else if (!getDirect())
+    {
+        o << ", False";
+    }
     o << ")";
     return o;
 }


### PR DESCRIPTION
Il est possible via l'IHM de choisir la première taille d'arêtes de maillage avec la loi beta de resserrement à la paroi, et le résultat semble cohérent au moment du maillage.
Cependant, la commande python écrite dans la console ne prend pas en compte la taille de la première maille, et laisse le paramètre beta par défaut à 1.01, comme ci-dessous:

```
# Changement de discrétisation pour les arêtes Ar0000
emp = Mgx3D.EdgeMeshingPropertyBeta(10,1.01)
ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
```

Donc à l'enregistrement du script python, on perd l'information de la première taille de maille imposée.

La commande suivante:

```
emp = Mgx3D.EdgeMeshingPropertyBeta(10,1.01,True,True,0.0001)
ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
```

tapée directement dans la console python semble elle fonctionner, et donner le même résultat que via l'IHM.
Le but de cette modification est donc de mettre en conformité l'écriture de la commande dans la console python.