### PR TITLE
issue-254: add tests for meshing laws

### DIFF
--- a/test_link/test_law_beta.py
+++ b/test_link/test_law_beta.py
@@ -1,0 +1,165 @@
+import pyMagix3D as Mgx3D
+import pytest
+import math
+import LimaScripting as lima
+
+def l2_norme(n0, n1):
+    return math.sqrt( pow(n1.x()-n0.x(),2) + pow(n1.y()-n0.y(),2) + pow(n1.z()-n0.z(),2) )
+
+
+def test_law_beta(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.005
+
+    # Création d'une boite avec une topologie
+    ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyBeta(10, 1.1, True, True, s1_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_beta.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar00000
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) < eps )
+
+
+
+# Beta law with target first mesh edge size seems to work only if this
+# size is smaller than what would be the uniform mesh edge size.
+def test_law_beta_onCurve_1(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.00008
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Vector(0, 0, 1), 3.600000e+02)
+    # Création d'un bloc topologique structuré sans projection (Vol0000)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0000")
+    # Affectation d'une projection vers Crb0000 pour les entités topologiques Ar0000
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0000"], "Crb0002", True)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyBeta(10, 1.1, True, True, s1_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_beta_2.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar00000
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n0, n8) - 0.000123750926732273) < eps )
+
+
+
+# Beta law with target first mesh edge size for a topological
+# edge associated to a geometric curve with the two topological
+# vertices matching the two geometric points bordering the curve.
+def test_law_beta_onCurve_2(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0001 = 0.00007
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, -1), 1, Mgx3D.Vector(0, 0, 2), 3.600000e+02)
+    # Création de la boite Vol0001
+    ctx.getGeomManager().newBox (Mgx3D.Point(1, 0, -1), Mgx3D.Point(-1, -2, 1))
+    # Fusion Booléenne de  Vol0001 Vol0000
+    ctx.getGeomManager ( ).fuse (["Vol0001","Vol0000"])
+    # Création d'un bloc topologique structuré sans projection (Vol0002)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0002")
+    # Affectation d'une projection vers Pt0000 pour les entités topologiques Som0007
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0007"], "Pt0000", True)
+    # Affectation d'une projection vers Pt0004 pour les entités topologiques Som0006
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0006"], "Pt0004", True)
+    # Affectation d'une projection vers Crb0015 pour les entités topologiques Ar0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0003"], "Crb0015", True)
+    # Affectation d'une projection vers Pt0001 pour les entités topologiques Som0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0003"], "Pt0001", True)
+    # Affectation d'une projection vers Pt0005 pour les entités topologiques Som0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0002"], "Pt0005", True)
+    # Affectation d'une projection vers Crb0017 pour les entités topologiques Ar0001
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0001"], "Crb0017", True)
+
+    # Changement de discrétisation pour les arêtes Ar0001
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, True, True, s1_ar0001)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0001"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_beta_3.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar00001
+    n2  = mesh_lima.noeud(2)
+    n17 = mesh_lima.noeud(17)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n2, n17) - s1_ar0001) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n2, n17) - 0.0000594519721850694) < eps )
+
+
+
+# This test case shows that the "Inverser le sens" option doesn't work when the
+# beta law is used with a target first mesh edge size. To show this, we use the
+# same test as "test_law_beta", which is successful, and the only
+# difference is we turn false the direction option.
+def test_law_beta_fail(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.005
+
+    # Création d'une boite avec une topologie
+    ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyBeta(10, 1.1, False, True, s1_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    with pytest.raises(RuntimeError) as excinfo:
+        # Création du maillage pour tous les blocs
+        ctx.getMeshManager().newAllBlocksMesh()
+    expected = "EdgeMeshingPropertyBeta, on ne peut pas trouver de beta"
+    assert expected in str(excinfo.value)

--- a/test_link/test_law_bigeometric.py
+++ b/test_link/test_law_bigeometric.py
@@ -1,0 +1,169 @@
+import pyMagix3D as Mgx3D
+import pytest
+import math
+import LimaScripting as lima
+
+def l2_norme(n0, n1):
+    return math.sqrt( pow(n1.x()-n0.x(),2) + pow(n1.y()-n0.y(),2) + pow(n1.z()-n0.z(),2) )
+
+
+# The bigeometric progression law with target mesh edge size on both sides
+# seems to work only if the two sizes are bigger than what would be the
+# uniform mesh edge size on the topological edge.
+def test_law_bigeometric_Linear(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.3
+    s2_ar0000 = 0.2
+    s1_ar0011 = 0.3
+    s2_ar0011 = 0.2
+
+    # Création d'une boite avec une topologie
+    ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyBigeometric(10,1,s1_ar0000,1,s2_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    # Changement de discrétisation pour les arêtes Ar0011
+    emp = Mgx3D.EdgeMeshingPropertyBigeometric(10,1,s1_ar0011,1,s2_ar0011, False)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0011"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_bigeometric.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar0000
+    # here, we show that the requested size is not
+    # obtained
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) > eps )
+    assert( abs(l2_norme(n0, n8) - 0.35) < eps )
+
+    # test of last mesh edge size of topo edge Ar0000
+    # here, we show that the requested size is not
+    # obtained
+    n1  = mesh_lima.noeud(1)
+    n16 = mesh_lima.noeud(16)
+    assert( abs(l2_norme(n1, n16) - s2_ar0000) > eps )
+    assert( abs(l2_norme(n1, n16) - 0.25) < eps )
+
+    # test of first mesh edge size of topo edge Ar0011
+    # here, we show that the requested size is not
+    # obtained
+    n6 = mesh_lima.noeud(6)
+    n115 = mesh_lima.noeud(115)
+    assert( abs(l2_norme(n6, n115) - s1_ar0011) > eps )
+    assert( abs(l2_norme(n6, n115) - 0.35) < eps )
+
+    # test of last mesh edge size of topo edge Ar0011
+    # here, we show that the requested size is not
+    # obtained
+    n2  = mesh_lima.noeud(2)
+    n107 = mesh_lima.noeud(107)
+    assert( abs(l2_norme(n2, n107) - s2_ar0000) > eps )
+    assert( abs(l2_norme(n2, n107) - 0.25) < eps )
+
+
+# This test shows an example of "Découpage polaire" option, with geometric law.
+# In 3D, it's difficult to get a suitable situation to use this option.
+# We highlight that it doesn't make sense to be able to pick a target first
+# mesh edge size, while applying this polar option. As the law applies on
+# angles, it does not take this size into account at all.
+def test_law_bigeometric_polar(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s_ar0000 = 0.3
+
+    # Création du sommet Pt0000
+    ctx.getGeomManager().newVertex (Mgx3D.Point(0, 0, 0))
+    # Création du sommet Pt0001
+    ctx.getGeomManager().newVertex (Mgx3D.Point(0, 1, 0))
+    # Création du sommet Pt0002
+    ctx.getGeomManager().newVertex (Mgx3D.Point(0, -1, 0))
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Vector(0, 0, 1), 3.600000e+02)
+    # Création du cylindre Vol0001
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1.4, Mgx3D.Vector(0, 0, 1), 3.600000e+02)
+    # Différences entre géométries avec plusieurs entités à couper
+    ctx.getGeomManager ( ).cut (["Vol0001"], ["Vol0000"])
+    # Création de la boite Vol0003
+    ctx.getGeomManager().newBox (Mgx3D.Point(2, 0, 0), Mgx3D.Point(-2, -2, 2))
+    # Différences entre géométries avec plusieurs entités à couper
+    ctx.getGeomManager ( ).cut (["Vol0002"], ["Vol0003"])
+    # Création d'un bloc topologique structuré sans projection (Vol0004)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0004")
+    # Affectation d'une projection vers Pt0003 pour les entités topologiques Som0005
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0005"], "Pt0003", True)
+    # Affectation d'une projection vers Pt0004 pour les entités topologiques Som0001
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0001"], "Pt0004", True)
+    # Affectation d'une projection vers Pt0005 pour les entités topologiques Som0007
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0007"], "Pt0005", True)
+    # Affectation d'une projection vers Pt0006 pour les entités topologiques Som0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0003"], "Pt0006", True)
+    # Affectation d'une projection vers Pt0015 pour les entités topologiques Som0004
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0004"], "Pt0015", True)
+    # Affectation d'une projection vers Pt0016 pour les entités topologiques Som0000
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0000"], "Pt0016", True)
+    # Affectation d'une projection vers Pt0017 pour les entités topologiques Som0006
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0006"], "Pt0017", True)
+    # Affectation d'une projection vers Pt0018 pour les entités topologiques Som0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0002"], "Pt0018", True)
+    # Affectation d'une projection vers Crb0022 pour les entités topologiques Ar0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0002"], "Crb0022", True)
+    # Affectation d'une projection vers Crb0019 pour les entités topologiques Ar0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0003"], "Crb0019", True)
+    # Affectation d'une projection vers Crb0023 pour les entités topologiques Ar0000
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0000"], "Crb0023", True)
+    # Affectation d'une projection vers Crb0021 pour les entités topologiques Ar0001
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0001"], "Crb0021", True)
+    # Affectation d'une projection vers Surf0015 pour les entités topologiques Fa0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Fa0002"], "Surf0015", True)
+    # Affectation d'une projection vers Surf0017 pour les entités topologiques Fa0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Fa0003"], "Surf0017", True)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyBigeometric(10,1,s_ar0000,1,s_ar0000, Mgx3D.Point(.45, 0, 0))
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_bigeometric_polar.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar0000
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n0, n8) - s_ar0000) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n0, n8) - 7.72599466265082e-1) < eps )
+
+    # test of last mesh edge size of topo edge Ar0000
+    n1  = mesh_lima.noeud(1)
+    n16 = mesh_lima.noeud(16)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n1, n16) - s_ar0000) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n1, n16) - 3.13783707036233e-1) < eps )

--- a/test_link/test_law_geometric.py
+++ b/test_link/test_law_geometric.py
@@ -1,0 +1,349 @@
+import pyMagix3D as Mgx3D
+import pytest
+import math
+import LimaScripting as lima
+
+def l2_norme(n0, n1):
+    return math.sqrt( pow(n1.x()-n0.x(),2) + pow(n1.y()-n0.y(),2) + pow(n1.z()-n0.z(),2) )
+
+# Geometric law with target first mesh edge size seems to work only if this
+# size is smaller than what would be the uniform mesh edge size.
+def test_law_geometric_Linear(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.02
+    s1_ar0004 = 0.04
+
+    # Création d'une boite avec une topologie
+    ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, True, True, s1_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    # Changement de discrétisation pour les arêtes Ar0004
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, False, True, s1_ar0004)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0004"])
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_geometric_1.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar00000
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) < eps )
+
+    # test of first mesh edge size of topo edge Ar00004
+    n5  = mesh_lima.noeud(5)
+    n52 = mesh_lima.noeud(52)
+    assert( abs(l2_norme(n5, n52) - s1_ar0004) < eps )
+
+
+
+# Geometric law with target first mesh edge size seems to work only if this
+# size is smaller than what would be the uniform mesh edge size.
+def test_law_geometric_onCurve_1(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.3
+    s1_ar0003 = 0.06
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Vector(0, 0, 1), 3.600000e+02)
+    # Création d'un bloc topologique structuré sans projection (Vol0000)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0000")
+    # Affectation d'une projection vers Crb0000 pour les entités topologiques Ar0000
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0000"], "Crb0002", True)
+    # Affectation d'une projection vers Crb0000 pour les entités topologiques Ar0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0003"], "Crb0000", True)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, True, True, s1_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    # Changement de discrétisation pour les arêtes Ar0003
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, False, True, s1_ar0003)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0003"])
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_geometric_2.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar00000
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n0, n8) - 0.331676774653951) < eps )
+
+    # test of first mesh edge size of topo edge Ar00003
+    n7  = mesh_lima.noeud(7)
+    n43 = mesh_lima.noeud(43)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n7, n43) - s1_ar0003) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n7, n43) - 0.0666309120859813) < eps )
+
+
+
+# Geometric law with target first mesh edge size for a topological
+# edge associated to a geometric curve with the two topological
+# vertices matching the two geometric points bordering the curve.
+def test_law_geometric_onCurve_2(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0001 = 0.00007
+    s1_ar0003 = 0.005
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, -1), 1, Mgx3D.Vector(0, 0, 2), 3.600000e+02)
+    # Création de la boite Vol0001
+    ctx.getGeomManager().newBox (Mgx3D.Point(1, 0, -1), Mgx3D.Point(-1, -2, 1))
+    # Fusion Booléenne de  Vol0001 Vol0000
+    ctx.getGeomManager ( ).fuse (["Vol0001","Vol0000"])
+    # Création d'un bloc topologique structuré sans projection (Vol0002)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0002")
+    # Affectation d'une projection vers Pt0000 pour les entités topologiques Som0007
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0007"], "Pt0000", True)
+    # Affectation d'une projection vers Pt0004 pour les entités topologiques Som0006
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0006"], "Pt0004", True)
+    # Affectation d'une projection vers Crb0015 pour les entités topologiques Ar0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0003"], "Crb0015", True)
+    # Affectation d'une projection vers Pt0001 pour les entités topologiques Som0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0003"], "Pt0001", True)
+    # Affectation d'une projection vers Pt0005 pour les entités topologiques Som0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0002"], "Pt0005", True)
+    # Affectation d'une projection vers Crb0017 pour les entités topologiques Ar0001
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0001"], "Crb0017", True)
+
+    # Changement de discrétisation pour les arêtes Ar0001
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, True, True, s1_ar0001)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0001"])
+    # Changement de discrétisation pour les arêtes Ar0003
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, False, True, s1_ar0003)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0003"])
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_geometric_3.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar00001
+    n2  = mesh_lima.noeud(2)
+    n17 = mesh_lima.noeud(17)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n2, n17) - s1_ar0001) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n2, n17) - 0.0000594519721850694) < eps )
+
+    # test of first mesh edge size of topo edge Ar00003
+    n7  = mesh_lima.noeud(7)
+    n43 = mesh_lima.noeud(43)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n7, n43) - s1_ar0003) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n7, n43) - 0.00473345420702485) < eps )
+
+
+
+# Geometric law with target first mesh edge size for a topological
+# edge associated to a geometric surface.
+def test_law_geometric_onSurface(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0023 = 0.0042
+    s1_ar0022 = 2.3
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Vector(0, 0, 4), 3.600000e+02)
+    # Création du cylindre Vol0001
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(1.5, 0, 0), 1, Mgx3D.Vector(0, 0, 4), 3.600000e+02)
+    # Fusion Booléenne de  Vol0001 Vol0000
+    ctx.getGeomManager ( ).fuse (["Vol0001","Vol0000"])
+    # Fusion de surfaces Surf0007 Surf0010 Surf0012
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0007","Surf0010","Surf0012"])
+    # Fusion de surfaces Surf0008 Surf0011 Surf0014
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0008","Surf0011","Surf0014"])
+    # Fusion de surfaces Surf0006 Surf0013
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0006","Surf0013"])
+    # Fusion de surfaces Surf0017 Surf0009
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0017","Surf0009"])
+    # Fusion de courbes Crb0006 Crb0016
+    ctx.getGeomManager ( ).joinCurves (["Crb0006","Crb0016"])
+    # Fusion de courbes Crb0018 Crb0009 Crb0008
+    ctx.getGeomManager ( ).joinCurves (["Crb0018","Crb0009","Crb0008"])
+    # Fusion de courbes Crb0020 Crb0007
+    ctx.getGeomManager ( ).joinCurves (["Crb0020","Crb0007"])
+    # Création d'un bloc topologique structuré sans projection (Vol0002)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0002")
+    # Découpage suivant Ar0011 des blocs Bl0000
+    ctx.getTopoManager().splitBlocks (["Bl0000"],"Ar0011", .5)
+    # Affectation d'une projection vers Surf0018 pour les entités topologiques Ar0023
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0023"], "Surf0018", True)
+    # Affectation d'une projection vers Surf0018 pour les entités topologiques Ar0022
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0022"], "Surf0018", True)
+
+    # Changement de discrétisation pour les arêtes Ar0023
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, True, True, s1_ar0023)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0023"])
+    # Changement de discrétisation pour les arêtes Ar0022
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.1, False, True, s1_ar0022)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0022"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_geometric_3.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar0023
+    n9   = mesh_lima.noeud(9)
+    n143 = mesh_lima.noeud(143)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n9, n143) - s1_ar0023) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n9, n143) - 3.94206709724702e-3) < eps )
+
+    # test of first mesh edge size of topo edge Ar0022
+    n8   = mesh_lima.noeud(8)
+    n142 = mesh_lima.noeud(142)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n8, n142) - s1_ar0022) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n8, n142) - 2.12853778510894) < eps )
+
+
+
+# This test shows an example of "Découpage polaire" option, with geometric law.
+# In 3D, it's difficult to get a suitable situation to use this option.
+# We highlight that it doesn't make sense to be able to pick a target first
+# mesh edge size, while applying this polar option. As the law applies on
+# angles, it does not take this size into account at all.
+def test_law_geometric_polar(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.4
+    s1_ar0001 = 0.4
+
+    # Création du sommet Pt0000
+    ctx.getGeomManager().newVertex (Mgx3D.Point(0, 0, 0))
+    # Création du sommet Pt0001
+    ctx.getGeomManager().newVertex (Mgx3D.Point(0, 1, 0))
+    # Création du sommet Pt0002
+    ctx.getGeomManager().newVertex (Mgx3D.Point(0, -1, 0))
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Vector(0, 0, 1), 3.600000e+02)
+    # Création du cylindre Vol0001
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1.4, Mgx3D.Vector(0, 0, 1), 3.600000e+02)
+    # Différences entre géométries avec plusieurs entités à couper
+    ctx.getGeomManager ( ).cut (["Vol0001"], ["Vol0000"])
+    # Création de la boite Vol0003
+    ctx.getGeomManager().newBox (Mgx3D.Point(2, 0, 0), Mgx3D.Point(-2, -2, 2))
+    # Différences entre géométries avec plusieurs entités à couper
+    ctx.getGeomManager ( ).cut (["Vol0002"], ["Vol0003"])
+    # Création d'un bloc topologique structuré sans projection (Vol0004)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0004")
+    # Affectation d'une projection vers Pt0003 pour les entités topologiques Som0005
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0005"], "Pt0003", True)
+    # Affectation d'une projection vers Pt0004 pour les entités topologiques Som0001
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0001"], "Pt0004", True)
+    # Affectation d'une projection vers Pt0005 pour les entités topologiques Som0007
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0007"], "Pt0005", True)
+    # Affectation d'une projection vers Pt0006 pour les entités topologiques Som0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0003"], "Pt0006", True)
+    # Affectation d'une projection vers Pt0015 pour les entités topologiques Som0004
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0004"], "Pt0015", True)
+    # Affectation d'une projection vers Pt0016 pour les entités topologiques Som0000
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0000"], "Pt0016", True)
+    # Affectation d'une projection vers Pt0017 pour les entités topologiques Som0006
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0006"], "Pt0017", True)
+    # Affectation d'une projection vers Pt0018 pour les entités topologiques Som0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0002"], "Pt0018", True)
+    # Affectation d'une projection vers Crb0022 pour les entités topologiques Ar0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0002"], "Crb0022", True)
+    # Affectation d'une projection vers Crb0019 pour les entités topologiques Ar0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0003"], "Crb0019", True)
+    # Affectation d'une projection vers Crb0023 pour les entités topologiques Ar0000
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0000"], "Crb0023", True)
+    # Affectation d'une projection vers Crb0021 pour les entités topologiques Ar0001
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0001"], "Crb0021", True)
+    # Affectation d'une projection vers Surf0015 pour les entités topologiques Fa0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Fa0002"], "Surf0015", True)
+    # Affectation d'une projection vers Surf0017 pour les entités topologiques Fa0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Fa0003"], "Surf0017", True)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.8, Mgx3D.Point(.4, 0, 0), True, True, s1_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    # Changement de discrétisation pour les arêtes Ar0001
+    emp = Mgx3D.EdgeMeshingPropertyGeometric(10, 1.8, Mgx3D.Point(.4, 0, 0), True, True, s1_ar0001)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0001"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_geometric_polar.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar0000
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n0, n8) - 5.49254666388343e-1) < eps )
+
+    # test of first mesh edge size of topo edge Ar0001
+    n2  = mesh_lima.noeud(2)
+    n17 = mesh_lima.noeud(17)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n2, n17) - s1_ar0001) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n2, n17) - 5.09996486467734e-1) < eps )

--- a/test_link/test_law_hyperbolic.py
+++ b/test_link/test_law_hyperbolic.py
@@ -1,0 +1,126 @@
+import pyMagix3D as Mgx3D
+import pytest
+import math
+import LimaScripting as lima
+
+def l2_norme(n0, n1):
+    return math.sqrt( pow(n1.x()-n0.x(),2) + pow(n1.y()-n0.y(),2) + pow(n1.z()-n0.z(),2) )
+
+
+def test_law_hyperbolic_Linear(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.06
+    s2_ar0000 = 0.008
+
+    # Création d'une boite avec une topologie
+    ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyHyperbolic(10,s1_ar0000,s2_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_hyperbolic.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar00000
+    # here, we show that the requested size is not
+    # obtained
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) > eps )
+    assert( abs(l2_norme(n0, n8) - 0.0114028117028031) < eps )
+
+    # test of last mesh edge size of topo edge Ar00000
+    # here, we show that the requested size is not
+    # obtained
+    n1  = mesh_lima.noeud(1)
+    n16 = mesh_lima.noeud(16)
+    assert( abs(l2_norme(n1, n16) - s2_ar0000) > eps )
+    assert( abs(l2_norme(n1, n16) - 0.0796198050777711) < eps )
+
+
+
+# Hyperbolic law with target first mesh edge size for a topological
+# edge associated to a geometric surface.
+def test_law_hyperbolic_onSurface(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0023 = 0.01
+    s2_ar0023 = 2.4
+    s1_ar0022 = 2.3
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Vector(0, 0, 4), 3.600000e+02)
+    # Création du cylindre Vol0001
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(1.5, 0, 0), 1, Mgx3D.Vector(0, 0, 4), 3.600000e+02)
+    # Fusion Booléenne de  Vol0001 Vol0000
+    ctx.getGeomManager ( ).fuse (["Vol0001","Vol0000"])
+    # Fusion de surfaces Surf0007 Surf0010 Surf0012
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0007","Surf0010","Surf0012"])
+    # Fusion de surfaces Surf0008 Surf0011 Surf0014
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0008","Surf0011","Surf0014"])
+    # Fusion de surfaces Surf0006 Surf0013
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0006","Surf0013"])
+    # Fusion de surfaces Surf0017 Surf0009
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0017","Surf0009"])
+    # Fusion de courbes Crb0006 Crb0016
+    ctx.getGeomManager ( ).joinCurves (["Crb0006","Crb0016"])
+    # Fusion de courbes Crb0018 Crb0009 Crb0008
+    ctx.getGeomManager ( ).joinCurves (["Crb0018","Crb0009","Crb0008"])
+    # Fusion de courbes Crb0020 Crb0007
+    ctx.getGeomManager ( ).joinCurves (["Crb0020","Crb0007"])
+    # Création d'un bloc topologique structuré sans projection (Vol0002)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0002")
+    # Découpage suivant Ar0011 des blocs Bl0000
+    ctx.getTopoManager().splitBlocks (["Bl0000"],"Ar0011", .5)
+    # Affectation d'une projection vers Surf0018 pour les entités topologiques Ar0023
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0023"], "Surf0018", True)
+    # Affectation d'une projection vers Surf0018 pour les entités topologiques Ar0022
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0022"], "Surf0018", True)
+
+    # Changement de discrétisation pour les arêtes Ar0023
+    emp = Mgx3D.EdgeMeshingPropertyHyperbolic(10,s1_ar0023,s2_ar0023)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0023"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_hyperbolic_surface.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar0023
+    n9   = mesh_lima.noeud(9)
+    n143 = mesh_lima.noeud(143)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n9, n143) - s2_ar0023) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n9, n143) - 1.48428681456749) < eps )
+
+    # test of last mesh edge size of topo edge Ar0023
+    n10   = mesh_lima.noeud(10)
+    n151 = mesh_lima.noeud(151)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n10, n151) - s1_ar0023) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n10, n151) - 0.0119670075859925) < eps )


### PR DESCRIPTION
This work aims to add python tests for meshing laws on topological edges.
I open a draft PR to get the information of codecoverage.