### PR TITLE
Fix issue#256: conversion on cartesian coordinates

### DIFF
--- a/src/QtComponents/QtMgx3DPointPanel.cpp
+++ b/src/QtComponents/QtMgx3DPointPanel.cpp
@@ -312,8 +312,20 @@ Math::Point QtMgx3DPointPanel::getPoint ( ) const
 	}	// if (false == ok)
 
 
-	Math::Point	point (x, y, z);
-
+	Math::Point	point;
+	coordinateType ct = getTypeCoordinate();
+	if (ct == cartesian){
+		point = Math::Point(x, y, z);
+	}
+	else if (ct == spherical){
+		point = Math::Point(Math::Spherical(x, y, z));
+	}
+	else if (ct == cylindrical){
+		point = Math::Point(Math::Cylindrical(x, y, z));
+	}
+	else
+		throw Exception ("Erreur interne, coordinateType de getPoint en dehors des clous");
+		
 	CoordinateSystem::SysCoord* rep = getSysCoord();
 
 	if (rep) {
@@ -583,7 +595,7 @@ void QtMgx3DPointPanel::coordTypeChangedCallback (int index)
 } // QtTopologyProjectVerticesPanel::coordTypeChangedCallback
 
 
-QtMgx3DPointPanel::coordinateType QtMgx3DPointPanel::getTypeCoordinate()
+QtMgx3DPointPanel::coordinateType QtMgx3DPointPanel::getTypeCoordinate() const
 {
 	CHECK_NULL_PTR_ERROR(_coordTypeComboBox);
 	if (_coordTypeComboBox->currentIndex() == 0)

--- a/src/QtComponents/QtMgx3DPointPanel.cpp
+++ b/src/QtComponents/QtMgx3DPointPanel.cpp
@@ -324,7 +324,7 @@ Math::Point QtMgx3DPointPanel::getPoint ( ) const
 		point = Math::Point(Math::Cylindrical(x, y, z));
 	}
 	else
-		throw Exception ("Erreur interne, coordinateType de getPoint en dehors des clous");
+		throw Exception ("Erreur interne, coordinateType de getPoint ne peut etre que cartesian, spherical ou cylindrical");
 		
 	CoordinateSystem::SysCoord* rep = getSysCoord();
 

--- a/src/QtComponents/protected/QtComponents/QtMgx3DPointPanel.h
+++ b/src/QtComponents/protected/QtComponents/QtMgx3DPointPanel.h
@@ -198,7 +198,7 @@ class QtMgx3DPointPanel : public QWidget
 	/**
 	 * Retourne le type de coordonnées utilisées
 	 */
-	virtual coordinateType getTypeCoordinate ();
+	virtual coordinateType getTypeCoordinate () const;
 
 	/** Nombre de caractères par défaut des champs numériques. Cette
 	 * valeur est initialement de 12. */


### PR DESCRIPTION
Allowing Python commands to be displayed with Spherical and Cylindrical cstr causes too many changes.
Consequently, the GUI always converts in cartesian coordinates.
