### PR TITLE
issue-121: add bi-exponential law

### DIFF
--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -14,7 +14,9 @@ set (HEADERS_DIRECTORIES protected/Geom protected/Group protected/Internal prote
 
 # On ajoute les en-têtes aux sources. C'est utile pour cmake dans certains cas,
 # par exemple lorsqu'ils doivent être pré-processés (moc, ...).
-add_library (Core ${CPP_SOURCES} ${HEADERS})
+add_library (Core ${CPP_SOURCES} ${HEADERS}
+        protected/Topo/EdgeMeshingPropertyBiexponential.h
+        Topo/EdgeMeshingPropertyBiexponential.cpp)
 
 set (CORE_OPTIONAL_LIBRARIES_LIST)
 

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -14,9 +14,7 @@ set (HEADERS_DIRECTORIES protected/Geom protected/Group protected/Internal prote
 
 # On ajoute les en-têtes aux sources. C'est utile pour cmake dans certains cas,
 # par exemple lorsqu'ils doivent être pré-processés (moc, ...).
-add_library (Core ${CPP_SOURCES} ${HEADERS}
-        protected/Topo/EdgeMeshingPropertyBiexponential.h
-        Topo/EdgeMeshingPropertyBiexponential.cpp)
+add_library (Core ${CPP_SOURCES} ${HEADERS})
 
 set (CORE_OPTIONAL_LIBRARIES_LIST)
 

--- a/src/Core/Topo/CoEdge.cpp
+++ b/src/Core/Topo/CoEdge.cpp
@@ -883,7 +883,9 @@ getRepresentation(Utils::DisplayRepresentation& dr, bool checkDestroyed) const
         } else if (m_mesh_property->getMeshLaw() == CoEdgeMeshingProperty::geometrique
         		|| m_mesh_property->getMeshLaw() == CoEdgeMeshingProperty::bigeometrique
         		|| m_mesh_property->getMeshLaw() == CoEdgeMeshingProperty::hyperbolique
-        		|| m_mesh_property->getMeshLaw() == CoEdgeMeshingProperty::beta_resserrement){
+        		|| m_mesh_property->getMeshLaw() == CoEdgeMeshingProperty::beta_resserrement
+                || m_mesh_property->getMeshLaw() == CoEdgeMeshingProperty::biexponential)
+        {
         	pos_carres.push_back(0.1);
         	pos_carres.push_back(0.2);
         	pos_carres.push_back(0.4);

--- a/src/Core/Topo/EdgeMeshingPropertyBiexponential.cpp
+++ b/src/Core/Topo/EdgeMeshingPropertyBiexponential.cpp
@@ -1,0 +1,286 @@
+#include "Topo/EdgeMeshingPropertyBiexponential.h"
+#include "Utils/Common.h"
+#include "Utils/MgxNumeric.h"
+#include <TkUtil/UTF8String.h>
+#include <TkUtil/Exception.h>
+
+/*----------------------------------------------------------------------------*/
+namespace Mgx3D {
+/*----------------------------------------------------------------------------*/
+namespace Topo {
+/*----------------------------------------------------------------------------*/
+EdgeMeshingPropertyBiexponential::
+EdgeMeshingPropertyBiexponential(const int nb, const double sp1, const double sp2, const bool isDirect)
+    : CoEdgeMeshingProperty(nb, biexponential, isDirect),
+      m_length(0.0),
+      m_sp1(sp1),
+      m_sp2(sp2)
+{
+    if (m_sp1 <= 0.0 || m_sp2 <= 0.0)
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
+        messErr << "EdgeMeshingPropertyBiexponential: ";
+        messErr << "la longueur des bras doivent être positives.";
+        throw TkUtil::Exception(messErr);
+    }
+
+    if (nb < 2)
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
+        messErr << "EdgeMeshingPropertyBiexponential: ";
+        messErr << "le nombre de bras doit être au moins de 2.";
+        throw TkUtil::Exception(messErr);
+    }
+}
+/*----------------------------------------------------------------------------*/
+EdgeMeshingPropertyBiexponential::
+EdgeMeshingPropertyBiexponential(const EdgeMeshingPropertyBiexponential &prop)
+    : CoEdgeMeshingProperty(prop.getNbEdges(), biexponential, prop.getDirect()),
+      m_length(prop.m_length),
+      m_sp1(prop.m_sp1),
+      m_sp2(prop.m_sp2)
+{
+    m_coeff.insert(m_coeff.end(), prop.m_coeff.begin(), prop.m_coeff.end());
+    m_is_polar = prop.m_is_polar;
+    m_polar_center = prop.m_polar_center;
+}
+
+/*----------------------------------------------------------------------------*/
+EdgeMeshingPropertyBiexponential::EdgeMeshingPropertyBiexponential(const CoEdgeMeshingProperty &prop)
+    : CoEdgeMeshingProperty(prop.getNbEdges(), biexponential, prop.getDirect()),
+      m_length(0.),
+      m_sp1(0.),
+      m_sp2(0.)
+{
+    const auto *bg = reinterpret_cast<const EdgeMeshingPropertyBiexponential *>(&prop);
+    if (!bg)
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
+        messErr << "EdgeMeshingPropertyBiexponential: ";
+        messErr << "la propriété transmise en argument n'est pas de type EdgeMeshingPropertyBiexponential.";
+        throw TkUtil::Exception(messErr);
+    }
+
+    m_sp1 = bg->m_sp1;
+    m_sp2 = bg->m_sp2;
+    m_length = bg->m_length;
+}
+
+/*----------------------------------------------------------------------------*/
+bool EdgeMeshingPropertyBiexponential::operator ==(const CoEdgeMeshingProperty &cedp) const
+{
+    const auto *props = dynamic_cast<const EdgeMeshingPropertyBiexponential *>(&cedp);
+    if (!props)
+    {
+        return false;
+    }
+
+    if ((m_sp1 != props->m_sp1) || (m_sp2 != props->m_sp2))
+    {
+        return false;
+    }
+
+    return CoEdgeMeshingProperty::operator ==(cedp);
+}
+/*----------------------------------------------------------------------------*/
+void EdgeMeshingPropertyBiexponential::initCoeff(const double length)
+{
+    m_length = length;
+    if (m_sp1 > m_length/2.0 || m_sp2 > m_length/2.0)
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
+        messErr << "EdgeMeshingPropertyBiexponential:";
+        messErr << "les tailles imposées doivent être plus petite que la moitié de la taille de l'arête. ";
+        messErr << "Taille de l'arête: " << m_length << ".";
+        throw TkUtil::Exception(messErr);
+    }
+
+    uint n1;
+    uint n2;
+    findNbrEdgesBalance(n1, n2);
+    const double paramExpo1 = computeParamExpo(m_sp1, m_length/2.0, n1);
+    const double paramExpo2 = computeParamExpo(m_sp2, m_length/2.0, n2);
+
+    std::vector<double> coeffs1 = computeCoeffs(paramExpo1, n1);
+    std::vector<double> coeffs2 = computeCoeffs(paramExpo2, n2);
+
+    m_coeff.clear();
+    for (int i =0; i < coeffs1.size(); i++)
+    {
+        m_coeff.push_back(coeffs1[i]/2.0);
+    }
+    for (int i=coeffs2.size()-2; i >= 0; i--)
+    {
+        m_coeff.push_back(0.5 + (1.0-coeffs2[i])/2.0);
+    }
+
+    // smooth the mid coeff, at the interface between the two laws
+    m_coeff[coeffs1.size()-1] = (m_coeff[coeffs1.size()-2]+m_coeff[coeffs1.size()])/2.0;
+
+    m_dernierIndice = 0;
+}
+/*----------------------------------------------------------------------------*/
+double EdgeMeshingPropertyBiexponential::
+nextCoeff()
+{
+    m_dernierIndice += 1;
+    double intermediateParameter(0.0);
+    if (m_sens)
+    {
+        intermediateParameter = m_coeff[m_dernierIndice];
+    }
+    else
+    {
+        intermediateParameter = 1.0-m_coeff[m_nb_edges-m_dernierIndice];
+    }
+    return intermediateParameter;
+}
+/*----------------------------------------------------------------------------*/
+TkUtil::UTF8String EdgeMeshingPropertyBiexponential::
+getScriptCommand() const
+{
+    TkUtil::UTF8String o(TkUtil::Charset::UTF_8);
+    o << getMgx3DAlias() << ".EdgeMeshingPropertyBiexponential("
+        << static_cast<long>(m_nb_edges) << ",";
+    if (getDirect())
+    {
+        o << Utils::Math::MgxNumeric::userRepresentation(m_sp1) << ", ";
+        o << Utils::Math::MgxNumeric::userRepresentation(m_sp2);
+    }
+    else
+    {
+        o << Utils::Math::MgxNumeric::userRepresentation(m_sp2) << ", ";
+        o << Utils::Math::MgxNumeric::userRepresentation(m_sp1);
+    }
+    o << ")";
+    return o;
+}
+
+/*----------------------------------------------------------------------------*/
+void EdgeMeshingPropertyBiexponential::
+addDescription(Utils::SerializedRepresentation &topoProprietes) const
+{
+    topoProprietes.addProperty(
+        Utils::SerializedRepresentation::Property("Longueur premier bras", m_sp1));
+    topoProprietes.addProperty(
+        Utils::SerializedRepresentation::Property("Longueur dernier bras", m_sp2));
+
+    if (getDirect())
+    {
+        topoProprietes.addProperty(
+            Utils::SerializedRepresentation::Property("Sens", std::string("direct")));
+    }
+    else
+    {
+        topoProprietes.addProperty(
+            Utils::SerializedRepresentation::Property("Sens", std::string("inverse")));
+    }
+}
+/*----------------------------------------------------------------------------*/
+double EdgeMeshingPropertyBiexponential::
+computeParamExpo(const double size, const double length, const uint nbrEdges)
+{
+    double paramExpo = 0.1;
+    // we normalize the tolerance by a characteristic length
+    const double eps = length*1e-9;
+    constexpr int maxIter = 100;
+    int iter = 0;
+    double F = 1.0;
+
+    while ( fabs(F) > eps && iter < maxIter)
+    {
+        const double u  = std::exp(paramExpo/nbrEdges) - 1.0;
+        const double v  = std::exp(paramExpo) - 1.0;
+        F = - size + length*(u/v);
+        const double up = (1.0/nbrEdges)*std::exp(paramExpo/nbrEdges);
+        const double vp = std::exp(paramExpo);
+        const double Fp = length*(up*v-u*vp)/(v*v);
+
+        if (Fp != 0.0)
+        {
+            paramExpo = paramExpo - F/Fp;
+        }
+
+        iter++;
+    }
+
+    return paramExpo;
+}
+/*----------------------------------------------------------------------------*/
+double
+EdgeMeshingPropertyBiexponential::computeIntermediateParameter(const double paramExpo, const double refParameter)
+{
+    return (std::exp(refParameter*paramExpo)-1.0)/(std::exp(paramExpo)-1.0);
+}
+/*----------------------------------------------------------------------------*/
+std::vector<double>
+EdgeMeshingPropertyBiexponential::computeCoeffs(const double paramExpo, const uint nbrEdges)
+{
+    std::vector<double> coeffs;
+    const double step = 1.0/nbrEdges;
+    coeffs.reserve(nbrEdges+1);
+    for (uint i=0; i<nbrEdges+1; i++)
+    {
+        coeffs.push_back(computeIntermediateParameter(paramExpo, i*step));
+    }
+    return coeffs;
+}
+/*----------------------------------------------------------------------------*/
+void
+EdgeMeshingPropertyBiexponential::findNbrEdgesBalance(uint &n1_min, uint &n2_min) const
+{
+    uint n1 = static_cast<uint>(m_nb_edges/2);
+    uint n2 = m_nb_edges-n1;
+    n1_min = n1;
+    n2_min = n2;
+
+    double paramExpo1 = computeParamExpo(m_sp1, m_length/2.0, n1);
+    double paramExpo2 = computeParamExpo(m_sp2, m_length/2.0, n2);
+
+    std::vector<double> coeffs1 = computeCoeffs(paramExpo1, n1);
+    std::vector<double> coeffs2 = computeCoeffs(paramExpo2, n2);
+
+    constexpr double eps(1e-6);
+    double minDif(fabs(coeffs1[n1-1]-coeffs2[n2-1]));
+    bool minReached(false);
+
+    while ( fabs(coeffs1[n1-1]-coeffs2[n2-1]) > eps
+            && !minReached
+            && n1 > 1
+            && n2 > 1)
+    {
+        if (coeffs1[n1-1] < coeffs2[n2-1])
+        {
+            n1 += 1;
+            n2 -= 1;
+        }
+        else
+        {
+            n1 -= 1;
+            n2 += 1;
+        }
+        paramExpo1 = computeParamExpo(m_sp1, m_length/2.0, n1);
+        paramExpo2 = computeParamExpo(m_sp2, m_length/2.0, n2);
+
+        coeffs1 = computeCoeffs(paramExpo1, n1);
+        coeffs2 = computeCoeffs(paramExpo2, n2);
+
+
+        if (fabs(coeffs1[n1-1]-coeffs2[n2-1]) > minDif)
+        {
+            minReached = true;
+        }
+        else
+        {
+            n1_min = n1;
+            n2_min = n2;
+            minDif = fabs(coeffs1[n1-1]-coeffs2[n2-1]);
+        }
+    }
+
+}
+/*----------------------------------------------------------------------------*/
+} // end namespace Topo
+/*----------------------------------------------------------------------------*/
+} // end namespace Mgx3D
+/*----------------------------------------------------------------------------*/

--- a/src/Core/protected/Topo/CoEdgeMeshingProperty.h
+++ b/src/Core/protected/Topo/CoEdgeMeshingProperty.h
@@ -56,6 +56,8 @@ public:
         tabulated,
         /// decoupage d'une arete en N segments selon une loi beta de resserrement
         beta_resserrement,
+        /// decoupage d'une arete en N segments selon une loi bi-exponentielle
+        biexponential,
     } meshLaw;
 
     /** Côté de départ pour les discrétisations orientés avec orthogonalité

--- a/src/Core/protected/Topo/EdgeMeshingPropertyBiexponential.h
+++ b/src/Core/protected/Topo/EdgeMeshingPropertyBiexponential.h
@@ -1,0 +1,149 @@
+#ifndef MAGIX3D_EDGEMESHINGPROPERTYBIEXPONENTIAL_H
+#define MAGIX3D_EDGEMESHINGPROPERTYBIEXPONENTIAL_H
+/*----------------------------------------------------------------------------*/
+#include "Topo/CoEdgeMeshingProperty.h"
+/*----------------------------------------------------------------------------*/
+namespace Mgx3D {
+/*----------------------------------------------------------------------------*/
+namespace Topo {
+/*----------------------------------------------------------------------------*/
+/**
+ * @brief Topological edge discretization property with two exponential
+ * progression law on the two different sides of the edge, with target
+ * sizes of the first and the last meshing edges.
+ *
+ *  0                              l/2                              l
+ *  o-------------------------------x-------------------------------o
+ *
+ * Considering the topological edge above, we split it at l/2, where l
+ * is the projected topological edge length. We distribute equally the
+ * number of mesh edges on both side, and compute on each side, an
+ * exponential law [1] to get the requested target first mesh size, on
+ * each side of the edge. Then, we compare the size of the meshing edges
+ * on both side of l/2 (where a meshing node is placed). If the size
+ * difference is too important, then we re-distribute the number of
+ * meshing edges from one side to another, until the difference is as
+ * small as possible.
+ *
+ * [1] THOMPSON, Joe F., SONI, Bharat K., et WEATHERILL, Nigel P. (ed.).
+ *     Handbook of grid generation. CRC press, 1998.
+ */
+class EdgeMeshingPropertyBiexponential : public CoEdgeMeshingProperty
+{
+public:
+
+    /*------------------------------------------------------------------------*/
+    /** @brief Constructor
+     *
+     * @param[in] nb is the number of meshing edges
+     * @param[in] sp1 is the target size of first meshing edge
+     * @param[in] sp2 is the target size of last meshing edge
+     */
+    EdgeMeshingPropertyBiexponential(int nb, double sp1, double sp2, bool isDirect=true);
+    /// Pour les pythoneries, cast par opérateur = :
+    EdgeMeshingPropertyBiexponential (const CoEdgeMeshingProperty&);
+
+    /*------------------------------------------------------------------------*/
+    /// Get name of meshing method.
+    std::string getMeshLawName() const override {return "Bi-Exponential";}
+
+#ifndef SWIG
+    /** Création d'un clone, on copie toutes les informations */
+    CoEdgeMeshingProperty* clone() override {return new  EdgeMeshingPropertyBiexponential(*this);}
+
+    /// Initialization before call to nextCoeff function.
+    void initCoeff(double length) override;
+
+    /// Return the next coefficient.
+    double nextCoeff() override;
+
+    /// Return true if the discretization needs the topological edge length information.
+    bool needLengthToInitialize() override {return true;}
+
+    /*------------------------------------------------------------------------*/
+    /// Python command script.
+    TkUtil::UTF8String getScriptCommand() const override;
+
+    /*------------------------------------------------------------------------*/
+    /** Add discretization specific information to textual representation.
+     */
+    void addDescription(Utils::SerializedRepresentation& topoProprietes) const override;
+
+    /*------------------------------------------------------------------------*/
+    /// Compare two meshing properties.
+    bool operator == (const CoEdgeMeshingProperty&) const override;
+
+#endif
+
+    /*------------------------------------------------------------------------*/
+    /// Return target sizes of first and last meshing edges.
+    virtual double getLength1() const { return m_sp1; }
+    virtual double getLength2() const { return m_sp2; }
+
+private:
+
+    /// Copy constructor
+    EdgeMeshingPropertyBiexponential(const EdgeMeshingPropertyBiexponential&);
+
+    /** @brief Compute exponential parameter corresponding to first mesh edge size
+     *
+     * @param[in] size is the target first meshing edge size
+     * @param[in] length is the topological edge lenght
+     * @param[in] nbrEdges is the number of meshing edges
+     *
+     * @return The value of the exponential parameter that respects the given
+     * constraints.
+     */
+    static double computeParamExpo(double size, double length, uint nbrEdges) ;
+
+    /** @brief Compute the intermediate parameter, which is a parameter
+     * between [0,1] that corresponds to the distribution of the
+     * exponential law, for parameter @paramExpo at param @refParameter.
+     *
+     * @param[in] paramExpo is the exponential parameter of the law
+     * @param[in] refParameter is a parameter in [0,1]
+     *
+     * @return The intermediate parameter, which is in [0,1].
+     */
+    static double computeIntermediateParameter(double paramExpo, double refParameter) ;
+
+    /** @brief Algorithm to find the balance of meshing edges distribution over
+     * the topological edge. We split the topological edge in two parts of same
+     * length. We compute an exponential law for each sub-topological edge to
+     * respect the first meshing edge sizes. Then, we compare the obtained
+     * meshing sizes at the junction between the two parts. We distribute the
+     * number of meshing edges from one side to the other, until the junction is
+     * as regular as possible.
+     *
+     * @param[inout] n1_min number of mesh edges on the first side
+     * @param[inout] n2_min number of mesh edges on the second sie
+     */
+    void findNbrEdgesBalance(uint &n1_min, uint &n2_min) const;
+
+    /** @brief Given the parameter of an exponential law, and the number of
+     * mesh edges over the domain [0,1], it computes the exponential
+     * distribution of points.
+     *
+     * @param[in] paramExpo is the exponential parameter
+     * @param[in] nbrEdges is the number of meshing edges
+     *
+     * @return The exponential distribution of points over [0,1]
+     */
+    static std::vector<double> computeCoeffs(double paramExpo, uint nbrEdges);
+
+private:
+    /// Projected/Physical topological edge length
+    double m_length;
+    /// Target size of first meshing edge
+    double m_sp1;
+    /// Target size of last meshing edge
+    double m_sp2;
+    /// Distribution of points in [0,1]
+    std::vector<double> m_coeff;
+};
+/*----------------------------------------------------------------------------*/
+} // end namespace Topo
+/*----------------------------------------------------------------------------*/
+} // end namespace Mgx3D
+/*----------------------------------------------------------------------------*/
+#endif //MAGIX3D_EDGEMESHINGPROPERTYBIEXPONENTIAL_H

--- a/src/QtComponents/QtEdgeMeshingPropertyAction.cpp
+++ b/src/QtComponents/QtEdgeMeshingPropertyAction.cpp
@@ -1604,6 +1604,164 @@ EdgeMeshingPropertyBeta*
 
 
 // ===========================================================================
+//                 LA CLASSE QtBiExponentialDiscretisationPanel
+// ===========================================================================
+
+QtBiExponentialDiscretisationPanel::QtBiExponentialDiscretisationPanel(
+    QWidget *parent,
+    const double length1,
+    const double length2,
+    QtMgx3DMainWindow &mw)
+    : QtDiscretisationPanelIfc(parent, mw),
+      _length1TextField(nullptr),
+      _length2TextField(nullptr),
+      _orientationCheckBox(nullptr)
+{
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    setLayout(layout);
+    layout->setContentsMargins(
+        Resources::instance()._margin.getValue(),
+        Resources::instance()._margin.getValue(),
+        Resources::instance()._margin.getValue(),
+        Resources::instance()._margin.getValue());
+    layout->setSpacing(Resources::instance()._spacing.getValue());
+
+    // Le premier bras côté 1 :
+    QHBoxLayout *hlayout = new QHBoxLayout();
+    layout->addLayout(hlayout);
+    QLabel *label = new QLabel(QString::fromUtf8("Longueur premier bras côté 1 :"), this);
+    hlayout->addWidget(label);
+    _length1TextField = &QtNumericFieldsFactory::createDistanceTextField(this);
+    _length1TextField->setValue(length1);
+    hlayout->addWidget(_length1TextField);
+    connect(_length1TextField, SIGNAL(editingFinished ( )), this,
+            SLOT(discretisationModifiedCallback ( )));
+
+    // Le premier bras côté 2 :
+    hlayout = new QHBoxLayout();
+    layout->addLayout(hlayout);
+    label = new QLabel(QString::fromUtf8("Longueur premier bras côté 2 :"), this);
+    hlayout->addWidget(label);
+    _length2TextField = &QtNumericFieldsFactory::createDistanceTextField(this);
+    _length2TextField->setValue(length2);
+    hlayout->addWidget(_length2TextField);
+    connect(_length2TextField, SIGNAL(editingFinished ( )), this,
+            SLOT(discretisationModifiedCallback ( )));
+
+    // Le sens de la discrétisation :
+    _orientationCheckBox = new QCheckBox("Inverser le sens", this);
+    layout->addWidget(_orientationCheckBox);
+    connect(_orientationCheckBox, SIGNAL(stateChanged (int)), this,
+            SLOT(discretisationModifiedCallback ( )));
+
+    // L'orthogonalité à la paroi :
+    createOrthogonalityArea(*layout);
+}
+
+
+QtBiExponentialDiscretisationPanel::QtBiExponentialDiscretisationPanel(
+    const QtBiExponentialDiscretisationPanel &p)
+    : QtDiscretisationPanelIfc(
+          nullptr,
+          *new QtMgx3DMainWindow(nullptr)),
+      _length1TextField(nullptr),
+      _length2TextField(nullptr),
+      _orientationCheckBox(nullptr)
+{
+    MGX_FORBIDDEN("QtBiExponentialDiscretisationPanel copy constructor is not allowed.");
+}
+
+
+QtBiExponentialDiscretisationPanel &
+QtBiExponentialDiscretisationPanel::operator =(
+    const QtBiExponentialDiscretisationPanel &)
+{
+    MGX_FORBIDDEN("QtBiExponentialDiscretisationPanel assignment operator is not allowed.");
+    return *this;
+}
+
+
+QtBiExponentialDiscretisationPanel::~QtBiExponentialDiscretisationPanel()
+{
+}
+
+
+void
+QtBiExponentialDiscretisationPanel::reset() {
+    BEGIN_QT_TRY_CATCH_BLOCK
+        CHECK_NULL_PTR_ERROR(_length1TextField)
+        CHECK_NULL_PTR_ERROR(_length2TextField)
+        _length1TextField->setValue(1.);
+        _length2TextField->setValue(1.);
+
+    COMPLETE_QT_TRY_CATCH_BLOCK(true, this, "Magix 3D")
+
+    QtDiscretisationPanelIfc::reset();
+}
+
+
+void
+QtBiExponentialDiscretisationPanel::setMeshingProperty(
+    const CoEdgeMeshingProperty &cemp)
+{
+    CHECK_NULL_PTR_ERROR(_length1TextField)
+    CHECK_NULL_PTR_ERROR(_length2TextField)
+    CHECK_NULL_PTR_ERROR(_orientationCheckBox)
+
+    const auto *properties = dynamic_cast<const EdgeMeshingPropertyBiexponential *>(&cemp);
+    if (!properties)
+    {
+        INTERNAL_ERROR(exc, "Les propriétés de maillage ne sont pas du type EdgeMeshingPropertyBiExponential.",
+                       "QtBiExponentialDiscretisationPanel::setMeshingProperty")
+        throw exc;
+    }
+
+    _length1TextField->setValue(properties->getLength1());
+    _length2TextField->setValue(properties->getLength2());
+    _orientationCheckBox->setCheckState(true == properties->getDirect() ? Qt::Unchecked : Qt::Checked);
+    QtDiscretisationPanelIfc::setMeshingProperty(cemp);
+}
+
+
+double
+QtBiExponentialDiscretisationPanel::getLength1() const
+{
+    CHECK_NULL_PTR_ERROR(_length1TextField)
+    return _length1TextField->getValue();
+}
+
+
+double
+QtBiExponentialDiscretisationPanel::getLength2() const
+{
+    CHECK_NULL_PTR_ERROR(_length2TextField)
+    return _length2TextField->getValue();
+}
+
+
+bool
+QtBiExponentialDiscretisationPanel::invertOrientation() const
+{
+    CHECK_NULL_PTR_ERROR(_orientationCheckBox)
+    return Qt::Checked == _orientationCheckBox->checkState() ? true : false;
+}
+
+
+EdgeMeshingPropertyBiexponential *
+QtBiExponentialDiscretisationPanel::getMeshingProperty(const size_t edgeNum) const
+{
+    auto *emp = new EdgeMeshingPropertyBiexponential(edgeNum,
+                                                     getLength1(),
+                                                     getLength2(),
+                                                     !invertOrientation());
+    updateProperty(*emp);
+
+    return emp;
+}
+
+
+
+// ===========================================================================
 //                   LA CLASSE QtEdgeMeshingPropertyPanelIfc
 // ===========================================================================
 
@@ -1690,7 +1848,9 @@ QtEdgeListMeshingPropertyPanel::QtEdgeListMeshingPropertyPanel (
 	  _uniformDiscretisationPanel (0), _geometricProgressionPanel (0),
 	  _specificSizePanel (0), _interpolatedPanel (0), _globalInterpolatedPanel(0),
 	  _bigeometricProgressionPanel (0), _hyperbolicPanel (0),
-	  _betaPanel (0), _edgesNumTextField (edgesNumTextField)
+	  _betaPanel (0),
+    _biexponentialPanel(nullptr),
+    _edgesNumTextField (edgesNumTextField)
 {
 //	SET_WIDGET_BACKGROUND (this, Qt::yellow)
 	QVBoxLayout*	layout	= new QVBoxLayout (this);
@@ -1716,6 +1876,7 @@ QtEdgeListMeshingPropertyPanel::QtEdgeListMeshingPropertyPanel (
 	_algorithmComboBox->addItem (QString::fromUtf8("Progression bi-géométrique"));
 	_algorithmComboBox->addItem (QString::fromUtf8("Progression hyperbolique"));
 	_algorithmComboBox->addItem (QString::fromUtf8("Loi beta de resserrement à la paroi"));
+    _algorithmComboBox->addItem (QString::fromUtf8("Progression bi-exponentielle"));
 	connect (_algorithmComboBox, SIGNAL (currentIndexChanged (int)),
 	         this, SLOT (algorithmCallback ( )));
 	hlayout->addWidget (_algorithmComboBox);
@@ -1836,6 +1997,22 @@ QtEdgeListMeshingPropertyPanel::QtEdgeListMeshingPropertyPanel (
 	         SIGNAL (discretisationModified ( )),
 	         this, SLOT (discretisationModifiedCallback ( )));
 
+    _biexponentialPanel	=
+            new QtBiExponentialDiscretisationPanel (nullptr, 1., 1., mainWindow);
+    _biexponentialPanel->hide();
+    connect(_biexponentialPanel,
+            SIGNAL(entitiesAddedToSelection(QString)),
+            this,
+            SLOT(entitiesAddedToSelectionCallback(QString)));
+    connect(_biexponentialPanel,
+            SIGNAL(entitiesRemovedFromSelection(QString)),
+            this,
+            SLOT(entitiesRemovedFromSelectionCallback(QString)));
+    connect(_biexponentialPanel,
+            SIGNAL(discretisationModified()),
+            this,
+            SLOT(discretisationModifiedCallback()));
+
 	vlayout->addStretch (2);
 
 	algorithmCallback ( );
@@ -1851,7 +2028,9 @@ QtEdgeListMeshingPropertyPanel::QtEdgeListMeshingPropertyPanel (
 	  _uniformDiscretisationPanel (0), _geometricProgressionPanel (0),
 	  _specificSizePanel (0), _interpolatedPanel (0), _globalInterpolatedPanel(0),
 	  _bigeometricProgressionPanel (0), _hyperbolicPanel (0),
-	  _betaPanel(0), _edgesNumTextField (0)
+	  _betaPanel(0),
+    _biexponentialPanel(nullptr),
+    _edgesNumTextField (0)
 {
 	MGX_FORBIDDEN ("QtEdgeListMeshingPropertyPanel copy constructor is not allowed.");
 }	// QtEdgeListMeshingPropertyPanel::QtEdgeListMeshingPropertyPanel (
@@ -1889,6 +2068,7 @@ CoEdgeMeshingProperty*
 	CHECK_NULL_PTR_ERROR (_bigeometricProgressionPanel)
 	CHECK_NULL_PTR_ERROR (_hyperbolicPanel)
 	CHECK_NULL_PTR_ERROR (_betaPanel)
+    CHECK_NULL_PTR_ERROR (_biexponentialPanel)
 
 
 	CHECK_NULL_PTR_ERROR (_edgesNumTextField)
@@ -1912,6 +2092,8 @@ CoEdgeMeshingProperty*
 			return _hyperbolicPanel->getMeshingProperty ( edgesNum );
 		case QtEdgeListMeshingPropertyPanel::BETA	:
 			return _betaPanel->getMeshingProperty ( edgesNum );
+        case QtEdgeListMeshingPropertyPanel::BI_EXPONENTIAL:
+            return _biexponentialPanel->getMeshingProperty ( edgesNum );
 	}	// switch (getAlgorithm ( ))
 
 	INTERNAL_ERROR (exc, "Méthode de discrétisation d'arête non supportée", "QtEdgeListMeshingPropertyPanel::getMeshingProperty")
@@ -1971,6 +2153,10 @@ void QtEdgeListMeshingPropertyPanel::setMeshingProperty (
 			newAlgo	= QtEdgeListMeshingPropertyPanel::BETA;
 			_edgesNumTextField->setValue (properties.getNbEdges ( ));
 			break;
+        case CoEdgeMeshingProperty::biexponential:
+            newAlgo	= QtEdgeListMeshingPropertyPanel::BI_EXPONENTIAL;
+            _edgesNumTextField->setValue (properties.getNbEdges());
+            break;
 		default	:
 			throw Exception (UTF8String ("Réinitialisation du panneau impossible : alorithme non supporté.", Charset::UTF_8));
 	}	// switch (properties.getMeshLaw ( ))
@@ -1998,6 +2184,7 @@ void QtEdgeListMeshingPropertyPanel::reset ( )
 	CHECK_NULL_PTR_ERROR (_bigeometricProgressionPanel)
 	CHECK_NULL_PTR_ERROR (_hyperbolicPanel)
 	CHECK_NULL_PTR_ERROR (_betaPanel)
+    CHECK_NULL_PTR_ERROR (_biexponentialPanel)
 	CHECK_NULL_PTR_ERROR (_edgesNumTextField)
 	_uniformDiscretisationPanel->reset ( );
 	_geometricProgressionPanel->reset ( );
@@ -2007,6 +2194,7 @@ void QtEdgeListMeshingPropertyPanel::reset ( )
 	_bigeometricProgressionPanel->reset ( );
 	_hyperbolicPanel->reset ( );
 	_betaPanel->reset ( );
+    _biexponentialPanel->reset();
 	_edgesNumTextField->setValue (10);
 
 	COMPLETE_QT_TRY_CATCH_BLOCK (true, this, "Magix 3D")
@@ -2048,6 +2236,7 @@ void QtEdgeListMeshingPropertyPanel::validate ( )
 		case QtEdgeListMeshingPropertyPanel::BI_GEOMETRIC			:
 		case QtEdgeListMeshingPropertyPanel::HYPERBOLIC				:
 		case QtEdgeListMeshingPropertyPanel::BETA		    		:
+	    case QtEdgeListMeshingPropertyPanel::BI_EXPONENTIAL:
 			break;
 		case -1	:
 			if (0 != error.length ( ))
@@ -2153,6 +2342,7 @@ void QtEdgeListMeshingPropertyPanel::algorithmCallback ( )
 	CHECK_NULL_PTR_ERROR (_bigeometricProgressionPanel)
 	CHECK_NULL_PTR_ERROR (_hyperbolicPanel)
 	CHECK_NULL_PTR_ERROR (_betaPanel)
+    CHECK_NULL_PTR_ERROR (_biexponentialPanel)
 	if (0 != _currentPanel)
 	{
 		_currentParentWidget->layout ( )->removeWidget (_currentPanel);
@@ -2195,6 +2385,10 @@ void QtEdgeListMeshingPropertyPanel::algorithmCallback ( )
 			_currentPanel	= _betaPanel;
 			_edgesNumTextField->setVisible(true);
 			break;
+        case QtEdgeListMeshingPropertyPanel::BI_EXPONENTIAL:
+            _currentPanel = _biexponentialPanel;
+            _edgesNumTextField->setVisible(true);
+            break;
 		default	:
 		{
 			UTF8String	message (Charset::UTF_8);

--- a/src/QtComponents/protected/QtComponents/QtEdgeMeshingPropertyAction.h
+++ b/src/QtComponents/protected/QtComponents/QtEdgeMeshingPropertyAction.h
@@ -19,6 +19,7 @@
 #include "Topo/EdgeMeshingPropertySpecificSize.h"
 #include "Topo/EdgeMeshingPropertyInterpolate.h"
 #include "Topo/EdgeMeshingPropertyGlobalInterpolate.h"
+#include "Topo/EdgeMeshingPropertyBiexponential.h"
 #include "Topo/EdgeMeshingPropertyBigeometric.h"
 #include "Topo/EdgeMeshingPropertyHyperbolic.h"
 #include "Topo/EdgeMeshingPropertyUniform.h"
@@ -827,6 +828,83 @@ class QtBetaDiscretisationPanel : public QtDiscretisationPanelIfc
 
 
 /**
+ * Le paramétrage d'un découpage bi-exponentiel.
+ */
+class QtBiExponentialDiscretisationPanel : public QtDiscretisationPanelIfc
+{
+    Q_OBJECT
+
+    public :
+
+    /**
+     * \param   Widget parent
+     * \param   Longueur des premiers bras aux extrémités.
+     * \param   Fenêtre principale <I>Magix 3D</I> de rattachement,
+     *          utilisée notamment pour récupérer le contexte.
+     */
+    QtBiExponentialDiscretisationPanel (QWidget* parent,
+                                       double length1,
+                                       double length2,
+                                       Mgx3D::QtComponents::QtMgx3DMainWindow& mw);
+
+    /**
+     * Destructeur. RAS.
+     */
+    ~QtBiExponentialDiscretisationPanel() override;
+
+    /**
+     * Réinitialise le panneau.
+     */
+    void reset() override;
+
+    /**
+     * Réinitialise le panneau à l'aide des propriétés de discrétisation
+     * transmises en  argument.
+     */
+    void setMeshingProperty(const Mgx3D::Topo::CoEdgeMeshingProperty&) override;
+
+    /**
+     * \return La longueur du bras à l'extrémité du côté 1.
+     */
+    virtual double getLength1() const;
+
+    /**
+     * \return La longueur du bras à l'extrémité du côté 2.
+     */
+    virtual double getLength2() const;
+
+    /**
+     * \return <I>true</I> s'il faut inverser l'orientation du découpage,
+     *         <I>false</I> dans le sens contraire.
+     */
+    virtual bool invertOrientation() const;
+
+    /**
+     * \param edgeNum le nombre de bras
+     * \return La propriété de maillage de l'arête conforme au panneau.
+     */
+    virtual Mgx3D::Topo::EdgeMeshingPropertyBiexponential*
+                                            getMeshingProperty( size_t edgeNum ) const;
+
+private :
+
+/**
+ * Constructeur de copie et opérateur = : interdits.
+ */
+QtBiExponentialDiscretisationPanel (const QtBiExponentialDiscretisationPanel&);
+    QtBiExponentialDiscretisationPanel& operator = (
+                                        const QtBiExponentialDiscretisationPanel&);
+
+    /** La saisie des longueurs des 2 bras aux extrémités. */
+    QtDoubleTextField *_length1TextField;
+    QtDoubleTextField *_length2TextField;
+
+    /** Faut il inverser le sens de discrétisation ? */
+    QCheckBox* _orientationCheckBox;
+};	// class QtBiExponentielDiscretisationPanel
+
+
+/**
  * Panneau générique d'édition des paramètres de maillage d'une liste d'arêtes
  * topologiques.
  */
@@ -933,11 +1011,12 @@ class QtEdgeListMeshingPropertyPanel : public QtEdgeMeshingPropertyPanelIfc
 	 * <LI>Interpolation avec une progression à chaque extrémité.
 	 * <LI>Interpolation avec une progression dite hyperbolique.
 	 * <LI>Interpolation avec loi de resserrement beta.
+	 * <LI>Discrétisation avec progressions bi-exponentielles.
 	 * </OL>
 	 */
 	enum ALGORITHM { UNIFORM, GEOMETRIC_PROGRESSION, SPECIFIC_SIZE,
 	                 INTERPOLATION, GLOBAL_INTERPOLATION, BI_GEOMETRIC,
-					 HYPERBOLIC, BETA };
+					 HYPERBOLIC, BETA, BI_EXPONENTIAL };
 
 	/**
 	 * Créé l'ihm.
@@ -1080,6 +1159,9 @@ class QtEdgeListMeshingPropertyPanel : public QtEdgeMeshingPropertyPanelIfc
 
 	/** Discrétisation avec beta resserrement. */
 	QtBetaDiscretisationPanel*              _betaPanel;
+
+    /** Discrétisation bi-exponentielle. */
+    QtBiExponentialDiscretisationPanel* _biexponentialPanel;
 
 	/** Lien sur le widget de sélection du nombre de bras */
 	QtIntTextField* _edgesNumTextField;

--- a/src/pyMagix3D/pyMagix3D.i
+++ b/src/pyMagix3D/pyMagix3D.i
@@ -46,6 +46,7 @@ using std::ptrdiff_t;
 #include "Topo/EdgeMeshingPropertyGlobalInterpolate.h"
 #include "Topo/EdgeMeshingPropertyTabulated.h"
 #include "Topo/EdgeMeshingPropertyBeta.h"
+#include "Topo/EdgeMeshingPropertyBiexponential.h"
 #include "Topo/FaceMeshingPropertyTransfinite.h"
 #include "Topo/FaceMeshingPropertyDelaunayGMSH.h"
 #include "Topo/FaceMeshingPropertyQuadPairing.h"
@@ -321,6 +322,7 @@ using std::ptrdiff_t;
 %include Topo/EdgeMeshingPropertyGlobalInterpolate.h
 %include Topo/EdgeMeshingPropertyTabulated.h
 %include Topo/EdgeMeshingPropertyBeta.h
+%include Topo/EdgeMeshingPropertyBiexponential.h
 %include Topo/CoFaceMeshingProperty.h
 %include Topo/FaceMeshingPropertyTransfinite.h
 %include Topo/FaceMeshingPropertyDelaunayGMSH.h

--- a/test_link/test_law_biexponential.py
+++ b/test_link/test_law_biexponential.py
@@ -1,0 +1,310 @@
+import pyMagix3D as Mgx3D
+import pytest
+import math
+import LimaScripting as lima
+
+def l2_norme(n0, n1):
+    return math.sqrt( pow(n1.x()-n0.x(),2) + pow(n1.y()-n0.y(),2) + pow(n1.z()-n0.z(),2) )
+
+
+def test_law_biexponential_Linear(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.3
+    s2_ar0000 = 0.2
+    s1_ar0011 = 0.3
+    s2_ar0011 = 0.2
+
+    # Création d'une boite avec une topologie
+    ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyBiexponential(10, s1_ar0000, s2_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    # Changement de discrétisation pour les arêtes Ar0011
+    emp = Mgx3D.EdgeMeshingPropertyBiexponential(10, s1_ar0011, s2_ar0011, False)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0011"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_biexponential.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test first mesh edge size of topo edge Ar0000
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) < eps )
+
+    # test last mesh edge size of topo edge Ar0000
+    n1  = mesh_lima.noeud(1)
+    n16 = mesh_lima.noeud(16)
+    assert( abs(l2_norme(n1, n16) - s2_ar0000) < eps )
+
+    # test first mesh edge size of topo edge Ar0011
+    n6 = mesh_lima.noeud(6)
+    n115 = mesh_lima.noeud(115)
+    assert( abs(l2_norme(n6, n115) - s1_ar0011) < eps )
+
+    # test last mesh edge size of topo edge Ar0011
+    n2  = mesh_lima.noeud(2)
+    n107 = mesh_lima.noeud(107)
+    assert( abs(l2_norme(n2, n107) - s2_ar0011) < eps )
+
+# Target sizes are not respected here. It is due to how
+# the projected topological edge length is computed in
+# the code. This also affects the other laws.
+def test_law_biexponential_onCurve_1(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0000 = 0.000001
+    s2_ar0000 = 0.05
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Vector(0, 0, 1), 3.600000e+02)
+    # Création d'un bloc topologique structuré sans projection (Vol0000)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0000")
+    # Affectation d'une projection vers Crb0000 pour les entités topologiques Ar0000
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0000"], "Crb0002", True)
+
+    # Changement de discrétisation pour les arêtes Ar0000
+    emp = Mgx3D.EdgeMeshingPropertyBiexponential(50, s1_ar0000, s2_ar0000)
+    ctx.getTopoManager().setParallelMeshingProperty (emp,"Ar0000")
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_biexponential.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar00000
+    n0 = mesh_lima.noeud(0)
+    n8 = mesh_lima.noeud(8)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n0, n8) - s1_ar0000) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n0, n8) - 1.11072074733155e-6) < eps )
+
+    # test of last mesh edge size of topo edge Ar00000
+    n1  = mesh_lima.noeud(1)
+    n56 = mesh_lima.noeud(56)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n1, n56) - s2_ar0000) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n1, n56) - 5.55289000397246e-2) < eps )
+
+    # we check now that the parallel edges has computed the
+    # positions to respect the target sizes.
+    # test of first mesh edge size of topo edge Ar00003
+    n6   = mesh_lima.noeud(6)
+    n155 = mesh_lima.noeud(155)
+    # target meshing edge size (here, the size is respected
+    # because the topological edge is straight)
+    assert( abs(l2_norme(n6, n155) - s1_ar0000) < eps )
+
+    # test of last mesh edge size of topo edge Ar00003
+    n7   = mesh_lima.noeud(7)
+    n203 = mesh_lima.noeud(203)
+    # target meshing edge size (here, the size is respected
+    # because the topological edge is straight)
+    assert( abs(l2_norme(n7, n203) - s2_ar0000) < eps )
+
+
+# Bi-exponential law with target first and last mesh edge size for a topological
+# edge associated to a geometric curve with the two topological
+# vertices matching the two geometric points bordering the curve.
+# Target sizes may not be respected because computed on curved
+# topological edge, while the final mesh is linear.
+def test_law_biexponential_onCurve_2(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0001 = 0.00007
+    s2_ar0001 = 0.003
+    s1_ar0003 = 0.2
+    s2_ar0003 = 0.4
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, -1), 1, Mgx3D.Vector(0, 0, 2), 3.600000e+02)
+    # Création de la boite Vol0001
+    ctx.getGeomManager().newBox (Mgx3D.Point(1, 0, -1), Mgx3D.Point(-1, -2, 1))
+    # Fusion Booléenne de  Vol0001 Vol0000
+    ctx.getGeomManager ( ).fuse (["Vol0001","Vol0000"])
+    # Création d'un bloc topologique structuré sans projection (Vol0002)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0002")
+    # Affectation d'une projection vers Pt0000 pour les entités topologiques Som0007
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0007"], "Pt0000", True)
+    # Affectation d'une projection vers Pt0004 pour les entités topologiques Som0006
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0006"], "Pt0004", True)
+    # Affectation d'une projection vers Crb0015 pour les entités topologiques Ar0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0003"], "Crb0015", True)
+    # Affectation d'une projection vers Pt0001 pour les entités topologiques Som0003
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0003"], "Pt0001", True)
+    # Affectation d'une projection vers Pt0005 pour les entités topologiques Som0002
+    ctx.getTopoManager ( ).setGeomAssociation (["Som0002"], "Pt0005", True)
+    # Affectation d'une projection vers Crb0017 pour les entités topologiques Ar0001
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0001"], "Crb0017", True)
+
+    # Changement de discrétisation pour les arêtes Ar0001
+    emp = Mgx3D.EdgeMeshingPropertyBiexponential(30, s1_ar0001, s2_ar0001)
+    ctx.getTopoManager().setParallelMeshingProperty (emp,"Ar0001")
+    # Changement de discrétisation pour les arêtes Ar0003
+    emp = Mgx3D.EdgeMeshingPropertyBiexponential(30, s1_ar0003, s2_ar0003)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0003"])
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_biexponential_3.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar0001
+    n2  = mesh_lima.noeud(2)
+    n37 = mesh_lima.noeud(37)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n2, n37) - s1_ar0001) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n2, n37) - 6.93887715010575e-5) < eps )
+
+    # test of last mesh edge size of topo edge Ar0001
+    n3  = mesh_lima.noeud(3)
+    n65 = mesh_lima.noeud(65)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n3, n65) - s2_ar0001) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n3, n65) - 2.97380451228687e-3) < eps )
+
+
+    # test of first mesh edge size of topo edge Ar0003
+    n6  = mesh_lima.noeud(6)
+    n95 = mesh_lima.noeud(95)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n6, n95) - s1_ar0003) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n6, n95) - 1.99666833293657e-1) < eps )
+
+    # test of last mesh edge size of topo edge Ar0003
+    n7   = mesh_lima.noeud(7)
+    n123 = mesh_lima.noeud(123)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n7, n123) - s2_ar0003) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n7, n123) - 3.97338661590123e-1) < eps )
+
+
+# Bi-exponential law with target first and last mesh edge size for a topological
+# edge associated to a geometric surface.
+def test_law_biexponential_onSurface(capfd):
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    mm = ctx.getMeshManager()
+
+    # chosen first mesh edge size
+    s1_ar0023 = 0.0042
+    s1_ar0022 = 0.8
+    s2_ar0022 = 0.5
+
+    # Création du cylindre Vol0000
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(0, 0, 0), 1, Mgx3D.Vector(0, 0, 4), 3.600000e+02)
+    # Création du cylindre Vol0001
+    ctx.getGeomManager().newCylinder (Mgx3D.Point(1.5, 0, 0), 1, Mgx3D.Vector(0, 0, 4), 3.600000e+02)
+    # Fusion Booléenne de  Vol0001 Vol0000
+    ctx.getGeomManager ( ).fuse (["Vol0001","Vol0000"])
+    # Fusion de surfaces Surf0007 Surf0010 Surf0012
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0007","Surf0010","Surf0012"])
+    # Fusion de surfaces Surf0008 Surf0011 Surf0014
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0008","Surf0011","Surf0014"])
+    # Fusion de surfaces Surf0006 Surf0013
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0006","Surf0013"])
+    # Fusion de surfaces Surf0017 Surf0009
+    ctx.getGeomManager ( ).joinSurfaces (["Surf0017","Surf0009"])
+    # Fusion de courbes Crb0006 Crb0016
+    ctx.getGeomManager ( ).joinCurves (["Crb0006","Crb0016"])
+    # Fusion de courbes Crb0018 Crb0009 Crb0008
+    ctx.getGeomManager ( ).joinCurves (["Crb0018","Crb0009","Crb0008"])
+    # Fusion de courbes Crb0020 Crb0007
+    ctx.getGeomManager ( ).joinCurves (["Crb0020","Crb0007"])
+    # Création d'un bloc topologique structuré sans projection (Vol0002)
+    ctx.getTopoManager().newFreeTopoOnGeometry ("Vol0002")
+    # Découpage suivant Ar0011 des blocs Bl0000
+    ctx.getTopoManager().splitBlocks (["Bl0000"],"Ar0011", .5)
+    # Affectation d'une projection vers Surf0018 pour les entités topologiques Ar0023
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0023"], "Surf0018", True)
+    # Affectation d'une projection vers Surf0018 pour les entités topologiques Ar0022
+    ctx.getTopoManager ( ).setGeomAssociation (["Ar0022"], "Surf0018", True)
+
+    # Changement de discrétisation pour les arêtes Ar0023
+    emp = Mgx3D.EdgeMeshingPropertyBiexponential(20, s1_ar0023, s1_ar0023)
+    ctx.getTopoManager().setParallelMeshingProperty (emp,"Ar0023")
+    # Changement de discrétisation pour les arêtes Ar0022
+    emp = Mgx3D.EdgeMeshingPropertyBiexponential(20, s1_ar0022, s2_ar0022)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0022"])
+
+    # Création du maillage pour tous les blocs
+    ctx.getMeshManager().newAllBlocksMesh()
+
+    # Sauvegarde du maillage (mli)
+    filename = "meshing_law_geometric_3.mli2"
+    mm.writeMli(filename)
+    mesh_lima = lima.Maillage()
+    mesh_lima.lire(filename)
+
+    # we choose a tolerance for tests on sizes
+    eps = 10e-9
+
+    # test of first mesh edge size of topo edge Ar0023
+    n9   = mesh_lima.noeud(9)
+    n193 = mesh_lima.noeud(193)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n9, n193) - s1_ar0023) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n9, n193) - 4.14588643711679e-3) < eps )
+
+    # test of last mesh edge size of topo edge Ar0023
+    n10  = mesh_lima.noeud(10)
+    n211 = mesh_lima.noeud(211)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n10, n211) - s1_ar0023) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n10, n211) - 4.15171460239938e-3) < eps )
+
+
+    # test of first mesh edge size of topo edge Ar0022
+    n11  = mesh_lima.noeud(11)
+    n174 = mesh_lima.noeud(174)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n11, n174) - s1_ar0022) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n11, n174) - 7.89083037828939e-1) < eps )
+
+    # test of last mesh edge size of topo edge Ar0022
+    n8   = mesh_lima.noeud(8)
+    n192 = mesh_lima.noeud(192)
+    # target meshing edge size (not respected)
+    assert( abs(l2_norme(n8, n192) - s2_ar0022) > eps )
+    # real meshing edge size
+    assert( abs(l2_norme(n8, n192) - 4.9378232958398e-1) < eps )


### PR DESCRIPTION
# PR content
* Add bi-exponential law, which is a new discretization method over the topological edges;
* Add python tests for this law, accordingly to the ones for other laws;
* Add the law in the GUI.

The bi-exponential law aims to make it possible to impose on a topological edge, the size of the first and last meshing edges.
Two laws are already available to do so: the bi-geometric, and the hyperbolic. However, for some ranges of values, they don't work properly. They can also produce a mesh that doesn't respect the requested sizes (see examples bellow).
The bi-exponential law is implemented here to handle those cases.

# To do so, we follow this process

First, we need 3 parameters as an input:
* N is the number of meshing edges over the topological edge
* $s_1$ is the target size of the first meshing edge
* $s_2$ is the target size of the last meshing edge

With those parameters, we compute the distribution over the topological edge.

 0  &emsp; &emsp; &emsp; &emsp; &emsp; &emsp;  &emsp; &ensp; L/2 &emsp; &emsp; &emsp; &emsp; &emsp; &emsp;  &emsp; L
 o-------------------------------x-------------------------------o
 Considering the topological edge above, we split it at L/2, where L is the **projected topological edge length**. We distribute equally the number of mesh edges on both side (the first one, on the portion [0,L/2], with the first target size, and the second one on the other portion [L/2, L]). We compute on each side, an exponential law [1] to get the requested target first mesh size, on each side of the edge (we note that the progression is inverted on the second portion, because the target size imposed is on the topological edge boundary). 
 0  &emsp; &emsp; &emsp; &emsp; &emsp; &emsp;  &emsp; &emsp; L/2 &emsp; &emsp; &emsp; &emsp; &emsp; &emsp;  &emsp; L
 x--o---o-----o-------o----------x-----------o-----------o-------x
&ensp;   $s_1$ &emsp; &emsp; &emsp; &emsp; &emsp; &emsp;  &emsp; &emsp; &emsp; &emsp; &emsp; &emsp; &emsp;  &emsp;  &emsp;  $s_2$
Then, we compare the size of the meshing edges on both side of L/2 (where a meshing node is placed). If the size difference is too important, then we re-distribute the number of meshing edges from one side to another, and we recompute both laws. We perform this meshing edges number distribution until the size difference is as small as possible.
During the whole process, we ensure that a meshing node is set at the position L/2. When the process is over, we add a last step to move this node. We take the mean position between its two adjacent points on the edge. It ensures a better continuity in case of a coarse distribution.

[1] THOMPSON, Joe F., SONI, Bharat K., et WEATHERILL, Nigel P. (ed.). Handbook of grid generation. CRC press, 1998.


# Practical test case

Here, test cases are performed on a unit square to highlight differences.
More test cases are available in the python unit tests.

## Test Case 1

```
# Nombre de bras par arête topologique
N = 100
# Tailles de la première et dernière arête de maille
s1 = 0.001
s2 = 0.00004
# Création d'un bloc unitaire mis dans le groupe aaa
ctx.getTopoManager().newFreeTopoInGroup ("aaa", 2)
# Changement de discrétisation pour Ar0002
emp = Mgx3D.EdgeMeshingPropertyBiexponential(N, s1, s2)
ctx.getTopoManager().setParallelMeshingProperty (emp,"Ar0002")
# Création du maillage pour toutes les faces
ctx.getMeshManager().newAllFacesMesh()
```

Results:

|       |              Bi-exponentielle              | Bi-géométrique |               Hyperbolique                |
| :---  |:------------------------------------------:|:--------------:|:-----------------------------------------:|
| $s_1$ |                  $0.001$                   |     ECHEC      |           $4.27027381395774e-5$           |
| $s_2$ |                 $0.00004$                  |     ECHEC      |           $1.0664754593549e-3$            |
| | <img src="https://github.com/user-attachments/assets/77d355ab-ce49-4aa8-b0df-3492c3dcd8dc" width=300> |     ECHEC      | <img src="https://github.com/user-attachments/assets/4f501727-e962-4a54-b8d0-0ca859d5a048" width=300> |


## Test Case 2

```
# Nombre de bras par arête topologique
N = 10
# Tailles de la première et dernière arête de maille
s1 = 0.2
s2 = 0.3
# Création d'un bloc unitaire mis dans le groupe aaa
ctx.getTopoManager().newFreeTopoInGroup ("aaa", 2)
# Changement de discrétisation pour Ar0002
emp = Mgx3D.EdgeMeshingPropertyBiexponential(N, s1, s2)
ctx.getTopoManager().setParallelMeshingProperty (emp,"Ar0002")
# Création du maillage pour toutes les faces
ctx.getMeshManager().newAllFacesMesh()
```

Results:

|       |              Bi-exponentielle              |               Bi-géométrique               | Hyperbolique |
| :---  |:------------------------------------------:|:------------------------------------------:|:------------:|
| $s_1$ |                   $0.2$                    |                   $0.25$                   |    ECHEC     |
| $s_2$ |                   $0.3$                    |                   $0.35$                   |    ECHEC     |
| | <img src="https://github.com/user-attachments/assets/0e43bf3a-4385-4569-af29-bcb38cc969c3" width=300> | <img src="https://github.com/user-attachments/assets/e52fda06-06d2-421d-89d9-847b34a37a04" width=300> |    ECHEC     |


## Test Case 3

```
# Nombre de bras par arête topologique
N = 100
# Tailles de la première et dernière arête de maille
s1 = 0.03
s2 = 0.002
# Création d'un bloc unitaire mis dans le groupe aaa
ctx.getTopoManager().newFreeTopoInGroup ("aaa", 2)
# Changement de discrétisation pour Ar0002
emp = Mgx3D.EdgeMeshingPropertyBiexponential(N, s1, s2)
ctx.getTopoManager().setParallelMeshingProperty (emp,"Ar0002")
# Création du maillage pour toutes les faces
ctx.getMeshManager().newAllFacesMesh()
```

Results:

|       |              Bi-exponentielle              | Bi-géométrique |               Hyperbolique                |
| :---  |:------------------------------------------:|:--------------:|:-----------------------------------------:|
| $s_1$ |           $2.99999999999999e-2$            |     ECHEC      |           $2.02596485804025e-3$           |
| $s_2$ |                  $0.002$                   |     ECHEC      |           $2.95512944924847e-2$           |
| | <img src="https://github.com/user-attachments/assets/b841f6de-e043-4b28-8ea4-20944938d8cf" width=300> |     ECHEC      | <img src="https://github.com/user-attachments/assets/d30b18bb-6be5-45f9-aaaf-e8345c6ebc83" width=300> |

This test case also highlight the fact that the **hyperbolic law** invert the sides for the chosen sizes.


## Test Case 4

```
# Nombre de bras par arête topologique
N = 100
# Tailles de la première et dernière arête de maille
s1 = 0.02
s2 = 0.02
# Création d'un bloc unitaire mis dans le groupe aaa
ctx.getTopoManager().newFreeTopoInGroup ("aaa", 2)
# Changement de discrétisation pour Ar0002
emp = Mgx3D.EdgeMeshingPropertyBiexponential(N, s1, s2)
ctx.getTopoManager().setParallelMeshingProperty (emp,"Ar0002")
# Création du maillage pour toutes les faces
ctx.getMeshManager().newAllFacesMesh()
```

Results:

|       |              Bi-exponentielle              |               Bi-géométrique               | Hyperbolique |
| :---  |:------------------------------------------:|:------------------------------------------:|:------------:|
| $s_1$ |                   $0.02$                   |                  $0.0296$                  |    ECHEC     |
| $s_2$ |                   $0.02$                   |                  $0.0296$                  |    ECHEC     |
| | <img src="https://github.com/user-attachments/assets/eb28e668-1171-4503-9941-3640e97b60ea" width=300> | <img src="https://github.com/user-attachments/assets/ef54623f-1631-49c3-adbb-d04b305738dd" width=300> |    ECHEC     |


## Test Case 5 (Anisotropic Topology)

```
# Nombre de bras par arête topologique
N = 100
# Tailles de la première et dernière arête de maille
s1 = 0.02
s2 = 0.02
# Création d'un bloc unitaire mis dans le groupe aaa
ctx.getTopoManager().newFreeTopoInGroup ("aaa", 2)
# Modification de la position des sommets topologiques Som0003 en coordonnées cartésiennes
ctx.getTopoManager ( ).setVertexLocation (["Som0003"], True, 1, True, .4, True, 0)
# Changement de discrétisation pour Ar0001
emp = Mgx3D.EdgeMeshingPropertyBiexponential(N, s1, s2)
ctx.getTopoManager().setParallelMeshingProperty (emp,"Ar0001")
# Création du maillage pour toutes les faces
ctx.getMeshManager().newAllFacesMesh()
```

<img src="https://github.com/user-attachments/assets/1940e7e4-5c4b-4de7-8de3-7a2827d3b1d1" width=400>
