### PR TITLE
issue-266: add biexponential law to .mgxt import/export format

### DIFF
--- a/src/Core/Topo/ExportBlocksImplementation.cpp
+++ b/src/Core/Topo/ExportBlocksImplementation.cpp
@@ -10,6 +10,8 @@
 #include "Topo/EdgeMeshingPropertySpecificSize.h"
 #include "Topo/EdgeMeshingPropertyInterpolate.h"
 #include "Topo/EdgeMeshingPropertyBeta.h"
+#include "Topo/EdgeMeshingPropertyBiexponential.h"
+
 /*----------------------------------------------------------------------------*/
 namespace Mgx3D {
 /*----------------------------------------------------------------------------*/
@@ -140,6 +142,19 @@ void ExportBlocksImplementation::writeEdges(std::ofstream &str, std::vector<Topo
                 case CoEdgeMeshingProperty::beta_resserrement:
                     str << 8 <<  " " << prop->getNbEdges() << " ";
                     str << dynamic_cast<EdgeMeshingPropertyBeta*>(prop)->getBeta() << "\n";
+                    break;
+                case CoEdgeMeshingProperty::biexponential:
+                    str << 9 <<  " " << prop->getNbEdges() << " ";
+                    if (dynamic_cast<EdgeMeshingPropertyBiexponential*>(prop)->getDirect())
+                    {
+                        str << dynamic_cast<EdgeMeshingPropertyBiexponential*>(prop)->getLength1() << " ";
+                        str << dynamic_cast<EdgeMeshingPropertyBiexponential*>(prop)->getLength2() << "\n";
+                    }
+                    else
+                    {
+                        str << dynamic_cast<EdgeMeshingPropertyBiexponential*>(prop)->getLength2() << " ";
+                        str << dynamic_cast<EdgeMeshingPropertyBiexponential*>(prop)->getLength1() << "\n";
+                    }
                     break;
                 default:
                     std::string s ="Arete avec une méthode de discrétisation inconnue";

--- a/src/Core/Topo/ImportBlocksImplementation.cpp
+++ b/src/Core/Topo/ImportBlocksImplementation.cpp
@@ -6,6 +6,7 @@
 #include "Topo/ImportBlocksImplementation.h"
 #include "Topo/EdgeMeshingPropertyUniform.h"
 #include "Topo/EdgeMeshingPropertyGeometric.h"
+#include "Topo/EdgeMeshingPropertyBiexponential.h"
 #include "Topo/EdgeMeshingPropertyBigeometric.h"
 #include "Topo/EdgeMeshingPropertyBeta.h"
 #include "Topo/EdgeMeshingPropertyHyperbolic.h"
@@ -472,6 +473,12 @@ void ImportBlocksImplementation::readDiscr(std::ifstream &str,const int &nbEdges
                     double beta;
                     str >> nb >> beta;
                     emps[i] = new EdgeMeshingPropertyBeta(nb, beta);
+                }
+                else if (disc_type == 9)
+                {
+                    double sp1, sp2;
+                    str >> nb >> sp1 >> sp2;
+                    emps[i] = new EdgeMeshingPropertyBiexponential(nb, sp1, sp2);
                 }
                 else {
                     std::string mess = "BLK read error: type of discretization not supported";


### PR DESCRIPTION
This PR aims to add the biexponential topological edge meshing law property to the export/import _.mgxt_ format.
Here is a simple test case (written with the Python API):
```
# Création d'un bloc unitaire mis dans le groupe test
ctx.getTopoManager().newFreeTopoInGroup ("test", 2)
# Changement de discrétisation pour les arêtes Ar0000
emp = Mgx3D.EdgeMeshingPropertyBiexponential(10, 0.05, .15)
ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
# Changement de discrétisation pour les arêtes Ar0002
emp = Mgx3D.EdgeMeshingPropertyBiexponential(10, 0.05, .15, False)
ctx.getTopoManager().setMeshingProperty (emp, ["Ar0002"])
# Création du maillage pour toutes les faces
ctx.getMeshManager().newAllFacesMesh()
```

with the result:
| Mesh before _.mgxt_ export| Mesh after _.mgxt_ import |
|:------------------------------------------:|:--------------:|
| <img src="https://github.com/user-attachments/assets/a4268c0b-527d-4648-b8ce-22429a5b6b41" width=400> | <img src="https://github.com/user-attachments/assets/02bff4ab-c3d4-4a95-9b66-ccf2b4ed6ab7" width=400> |

We checked, and the requested target sizes are respected after the import.