### PR TITLE
Fix issue#261: mesh becomes invisible if associated geom and topo entities in same group

### DIFF
--- a/src/Core/Topo/CommandSetGeomAssociation.cpp
+++ b/src/Core/Topo/CommandSetGeomAssociation.cpp
@@ -147,16 +147,12 @@ void CommandSetGeomAssociation::validGeomEntity()
 /*----------------------------------------------------------------------------*/
 void CommandSetGeomAssociation::project(Block* bloc)
 {
-	getInfoCommand().addTopoInfoEntity(bloc, Internal::InfoCommand::DISPMODIFIED);
-	bloc->saveTopoProperty();
-	bloc->setGeomAssociation(m_geom_entity);
+	setGeomAssociation(bloc, [bloc](Internal::InfoCommand* icmd) { bloc->saveBlockTopoProperty(icmd); });
 }
 /*----------------------------------------------------------------------------*/
 void CommandSetGeomAssociation::project(CoFace* coface)
 {
-	getInfoCommand().addTopoInfoEntity(coface, Internal::InfoCommand::DISPMODIFIED);
-	coface->saveTopoProperty();
-	coface->setGeomAssociation(m_geom_entity);
+	setGeomAssociation(coface, [coface](Internal::InfoCommand* icmd) { coface->saveCoFaceTopoProperty(icmd); });
 
 	std::vector<CoEdge*> coedges = coface->getCoEdges();
 
@@ -210,9 +206,7 @@ void CommandSetGeomAssociation::project(CoFace* coface)
 /*----------------------------------------------------------------------------*/
 void CommandSetGeomAssociation::project(CoEdge* coedge)
 {
-	getInfoCommand().addTopoInfoEntity(coedge, Internal::InfoCommand::DISPMODIFIED);
-	coedge->saveTopoProperty();
-	coedge->setGeomAssociation(m_geom_entity);
+	setGeomAssociation(coedge, [coedge](Internal::InfoCommand* icmd) { coedge->saveCoEdgeTopoProperty(icmd); });
 
 	const std::vector<Vertex*>& vertices = coedge->getVertices();
 	for (auto iter = vertices.begin(); iter != vertices.end(); ++iter){
@@ -229,8 +223,7 @@ void CommandSetGeomAssociation::project(CoEdge* coedge)
 /*----------------------------------------------------------------------------*/
 void CommandSetGeomAssociation::project(Vertex* vtx)
 {
-	vtx->saveTopoProperty();
-	vtx->setGeomAssociation(m_geom_entity);
+	setGeomAssociation(vtx, [vtx](Internal::InfoCommand* icmd) { vtx->saveVertexTopoProperty(icmd); });
 
 	// déplace le sommet topologique si la projection implique un déplacement
 	if (m_geom_entity && m_move_vertices){
@@ -258,12 +251,42 @@ void CommandSetGeomAssociation::project(Vertex* vtx)
 			}
 		}
 	}
-	getInfoCommand().addTopoInfoEntity(vtx, Internal::InfoCommand::DISPMODIFIED);
 }
 /*----------------------------------------------------------------------------*/
 void CommandSetGeomAssociation::getPreviewRepresentation(Utils::DisplayRepresentation& dr)
 {
 	return getPreviewRepresentationCoedgeDisplayModified(dr);
+}
+/*----------------------------------------------------------------------------*/
+void CommandSetGeomAssociation::setGeomAssociation(TopoEntity* e, std::function<void(Internal::InfoCommand* icmd)> saveGroups)
+{
+	getInfoCommand().addTopoInfoEntity(e, Internal::InfoCommand::DISPMODIFIED);
+	e->saveTopoProperty();
+	e->setGeomAssociation(m_geom_entity);
+
+	// si m_geom_entity est dans le même groupe que e => e sort du groupe
+	// 1. les groupes géométriques
+	Group::GroupManager& gm = e->getContext().getGroupManager();
+	std::vector<std::string> geom_groups = Utils::toNames(gm.getGroupsFor(m_geom_entity));
+	std::sort(geom_groups.begin(), geom_groups.end());
+	// 2. les groupes topologiques
+	Group::GroupHelperForCommand helper(getInfoCommand(), gm);
+	std::vector<std::string> topo_groups = Utils::toNames(helper.getGroupsFor(e));
+	std::sort(topo_groups.begin(), topo_groups.end());
+	// 3. l'intersection
+	std::vector<std::string> common_groups;
+	std::set_intersection(
+        geom_groups.begin(), geom_groups.end(),
+        topo_groups.begin(), topo_groups.end(),
+        std::back_inserter(common_groups)
+    );
+	// 4. suppression des groupes
+	if (common_groups.size() > 0) {
+		// au moins un groupe à supprimer, il faut sauvegarder les listes de groupes
+		saveGroups(&getInfoCommand());
+		for (std::string gn : common_groups)
+			helper.removeFromGroup(gn, e);
+	}
 }
 /*----------------------------------------------------------------------------*/
 } // end namespace Topo

--- a/src/Core/Topo/TopoEntity.cpp
+++ b/src/Core/Topo/TopoEntity.cpp
@@ -116,13 +116,14 @@ setGeomAssociation(Geom::GeomEntity* ge)
 
     // on met à jour la relation réciproque (de Geom vers Topo)
     Topo::TopoManager& tm = getContext().getTopoManager();
-    if (m_topo_property->getGeomAssociation())
-        tm.removeRefTopo(m_topo_property->getGeomAssociation(), this);
+    Geom::GeomEntity* oldGe = m_topo_property->getGeomAssociation();
+    if (oldGe)
+        tm.removeRefTopo(oldGe, this);
+
     if (ge)
         tm.addRefTopo(ge, this);
 
     // mise à jour de la couleur si changement de dimension pour la projection
-    Geom::GeomEntity* oldGe = m_topo_property->getGeomAssociation();
     bool need_update_color = (0==ge || 0==oldGe || ge->getDim() != oldGe->getDim());
 
     // la relation Topo vers Geom

--- a/src/Core/protected/Group/GroupHelperForCommand.h
+++ b/src/Core/protected/Group/GroupHelperForCommand.h
@@ -79,8 +79,7 @@ private:
         group->remove(e);
         e->remove(group);
 
-        // il faut peut-être ajouter le groupe par défaut
-        if (e->getNbGroups() == 0) {
+        if (e->getNbGroups() == 0 && e->getGeomAssociation() == 0) {
             addToGroup("", e);
         }
 

--- a/src/Core/protected/Topo/CommandSetGeomAssociation.h
+++ b/src/Core/protected/Topo/CommandSetGeomAssociation.h
@@ -79,6 +79,7 @@ public:
     virtual void getPreviewRepresentation(Utils::DisplayRepresentation& dr);
 
 private:
+    void setGeomAssociation(TopoEntity* e, std::function<void(Internal::InfoCommand* icmd)> saveGroups);
 
     /*------------------------------------------------------------------------*/
     /** Met à jour l'association et c'est tout */

--- a/test_link/test_groups.py
+++ b/test_link/test_groups.py
@@ -272,43 +272,54 @@ def test_two_adds(capfd):
 def test_geom_assoc1():
     ctx = Mgx3D.getStdContext()
     ctx.clearSession() # Clean the session after the previous test
+    gm = ctx.getGeomManager()
     tm = ctx.getTopoManager()
 
     # Création de la boite Vol0000
-    ctx.getGeomManager().newBox (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1))
-    # Création d'un sommet géométrique par coordonnées
-    tm.newTopoVertex (Mgx3D.Point(0, 0, 0),"")
+    gm.newBox (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1))
+    assert gm.getInfos("Pt0001", 0).groups() == ['Hors_Groupe_0D']
 
+    # Création d'un sommet géométrique par coordonnées
+    tm.newTopoVertex (Mgx3D.Point(0, 0, 0), "")
     assert tm.getInfos("Som0000", 0).groups() == ['Hors_Groupe_0D']
 
     # Affectation d'une projection vers Pt0001 pour les entités topologiques Som0000
-    # L'association ne peut se faire car le groupe Hors_Groupe_0D possède Pt0001 ainsi que Som0000
-    # Il est recommandé de supprimer la topologie du groupe
+    # Som0000 va être sorti du groupe Hors_Groupe_0D car Pt0001 appartient à Hors_Groupe_0D
+    # Som0000 va donc hériter de ce groupe par associativité
     tm.setGeomAssociation (["Som0000"], "Pt0001", True)
+    assert gm.getInfos("Pt0001", 0).groups() == ['Hors_Groupe_0D']
+    assert tm.getInfos("Som0000", 0).groups() == []
 
+    ctx.undo()
+    assert gm.getInfos("Pt0001", 0).groups() == ['Hors_Groupe_0D']
     assert tm.getInfos("Som0000", 0).groups() == ['Hors_Groupe_0D']
 
 def test_geom_assoc2():
     ctx = Mgx3D.getStdContext()
     ctx.clearSession() # Clean the session after the previous test
+    gm = ctx.getGeomManager()
     tm = ctx.getTopoManager()
 
     # Création de la boite Vol0000
     ctx.getGeomManager().newBox (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1))
     # Modifie le groupe A
     ctx.getGeomManager().addToGroup (["Pt0001"], 0, "A")
+    assert gm.getInfos("Pt0001", 0).groups() == ['A']
 
     # Création d'un sommet géométrique par coordonnées
     tm.newTopoVertex (Mgx3D.Point(0, 0, 0),"A")
-
     assert tm.getInfos("Som0000", 0).groups() == ['A']
 
     # Affectation d'une projection vers Pt0001 pour les entités topologiques Som0000
-    # L'association ne peut se faire car le groupe Hors_Groupe_0D possède Pt0001 ainsi que Som0000
-    # Il est recommandé de supprimer la topologie du groupe
+    # Som0000 va être sorti du groupe A car Pt0001 appartient à A
+    # Som0000 va donc hériter de ce groupe par associativité
     tm.setGeomAssociation (["Som0000"], "Pt0001", True)
+    assert tm.getInfos("Som0000", 0).groups() == []
+    assert gm.getInfos("Pt0001", 0).groups() == ['A']
 
+    ctx.undo()
     assert tm.getInfos("Som0000", 0).groups() == ['A']
+    assert gm.getInfos("Pt0001", 0).groups() == ['A']
 
 # issue#245: undo on addToGroup raises an error
 def test_topo_surface():
@@ -352,3 +363,56 @@ def test_issue265():
     gm.setGroup(["Vol0001"], 3, "aaa")
     assert gm.getInfos("Vol0000", 3).groups() == ["aaa"]
     assert gm.getInfos("Vol0001", 3).groups() == ["aaa"]
+
+# mesh becomes invisible during geom association
+def test_issue261_1():
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    gm = ctx.getGeomManager()
+    tm = ctx.getTopoManager()
+
+    gn = "test"
+    # Création de la boite Vol0000
+    gm.newBox (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), gn)
+    assert gm.getInfos("Vol0000", 3).groups() == [gn]
+
+    # Création d'un bloc unitaire mis dans le groupe test
+    tm.newFreeTopoInGroup (gn, 3)
+    assert tm.getInfos("Bl0000", 3).groups() == [gn]
+
+    # Affectation d'une projection vers Vol0000 pour les entités topologiques Bl0000
+    tm.setGeomAssociation (["Bl0000"], "Vol0000", False)
+    # lors de l'association, Bl0000 doit être retiré de gn car il en "hérite" par la géométrie
+    assert tm.getInfos("Bl0000", 3).groups() == []
+    assert gm.getInfos("Vol0000", 3).groups() == [gn]
+
+    # test du undo
+    ctx.undo()
+    assert tm.getInfos("Bl0000", 3).groups() == [gn]
+    assert gm.getInfos("Vol0000", 3).groups() == [gn]
+
+def test_issue261_2():
+    ctx = Mgx3D.getStdContext()
+    ctx.clearSession() # Clean the session after the previous test
+    gm = ctx.getGeomManager()
+    tm = ctx.getTopoManager()
+
+    gn = "Hors_Groupe_3D"
+    # Création de la boite Vol0000
+    gm.newBox (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1))
+    assert gm.getInfos("Vol0000", 3).groups() == [gn]
+
+    # Création d'un bloc unitaire mis dans le groupe test
+    tm.newFreeTopoInGroup (gn, 3)
+    assert tm.getInfos("Bl0000", 3).groups() == [gn]
+
+    # Affectation d'une projection vers Vol0000 pour les entités topologiques Bl0000
+    tm.setGeomAssociation (["Bl0000"], "Vol0000", False)
+    # lors de l'association, Bl0000 doit être retiré de gn car il en "hérite" par la géométrie
+    assert tm.getInfos("Bl0000", 3).groups() == []
+    assert gm.getInfos("Vol0000", 3).groups() == [gn]
+
+    # test du undo
+    ctx.undo()
+    assert tm.getInfos("Bl0000", 3).groups() == [gn]
+    assert gm.getInfos("Vol0000", 3).groups() == [gn]


### PR DESCRIPTION
Mesh is invisible if topo entity and geom entity belong to the same group
