### PR TITLE
issue-273: fix bug beta law indirect direction

### DIFF
--- a/src/Core/Topo/EdgeMeshingPropertyBeta.cpp
+++ b/src/Core/Topo/EdgeMeshingPropertyBeta.cpp
@@ -1,12 +1,4 @@
 /*----------------------------------------------------------------------------*/
-/*
- * \file EdgeMeshingPropertyBeta.cpp
- *
- *  \author Eric Brière de l'Isle
- *
- *  \date 24 janv. 2012
- */
-/*----------------------------------------------------------------------------*/
 #include "Topo/EdgeMeshingPropertyBeta.h"
 #include "Utils/Common.h"
 #include "Utils/MgxNumeric.h"
@@ -17,89 +9,108 @@ namespace Mgx3D {
 /*----------------------------------------------------------------------------*/
 namespace Topo {
 /*----------------------------------------------------------------------------*/
-//#define _DEBUG_beta
-/*----------------------------------------------------------------------------*/
 EdgeMeshingPropertyBeta::
-EdgeMeshingPropertyBeta(int nbBras, double beta, bool isDirect,
-	bool initWithFirstEdge, double meshingEdgeLength)
-: CoEdgeMeshingProperty(nbBras, beta_resserrement, isDirect)
-, m_beta(beta)
-, m_arm1(meshingEdgeLength)
-, m_initWithArm1(initWithFirstEdge)
+EdgeMeshingPropertyBeta(const int nbBras, const double beta, const bool isDirect,
+                        const bool initWithFirstEdge, const double meshingEdgeLength)
+    : CoEdgeMeshingProperty(nbBras, beta_resserrement, isDirect)
+      , m_beta(beta)
+      , m_arm1(meshingEdgeLength)
+      , m_initWithArm1(initWithFirstEdge)
 {
-    if (!m_initWithArm1 && (m_beta<1.00001 || m_beta>1.01)){
-		TkUtil::UTF8String	messErr (TkUtil::Charset::UTF_8);
-        messErr << "EdgeMeshingPropertyBeta, la valeur de beta doit être comprise entre 1 et 1.01, actuellement : "<<m_beta;
+    if (!m_initWithArm1 && (m_beta < 1.00001 || m_beta > 1.01))
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
+        messErr << "EdgeMeshingPropertyBeta: ";
+        messErr << "la valeur de beta doit être comprise entre 1 et 1.01, actuellement : ";
+        messErr << m_beta;
         throw TkUtil::Exception(messErr);
     }
-   if (m_initWithArm1 && m_arm1 < 0){
-		TkUtil::UTF8String	messErr (TkUtil::Charset::UTF_8);
-    	messErr << "EdgeMeshingPropertyGeometric, la longueur du premier bras ne doit pas être négative : "<<m_arm1;
-    	throw TkUtil::Exception(messErr);
+    if (m_initWithArm1 && m_arm1 < 0)
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
+        messErr << "EdgeMeshingPropertyBeta: ";
+        messErr << "la longueur du premier bras ne doit pas être négative : ";
+        messErr << m_arm1;
+        throw TkUtil::Exception(messErr);
     }
     if (nbBras < 1)
-        throw TkUtil::Exception (TkUtil::UTF8String ("EdgeMeshingPropertyBeta, le nombre de bras doit être au moins de 1", TkUtil::Charset::UTF_8));
+    {
+        throw TkUtil::Exception(TkUtil::UTF8String(
+            "EdgeMeshingPropertyBeta, le nombre de bras doit être au moins de 1", TkUtil::Charset::UTF_8));
+    }
 }
+
 /*----------------------------------------------------------------------------*/
-EdgeMeshingPropertyBeta::EdgeMeshingPropertyBeta (const CoEdgeMeshingProperty& prop)
-: CoEdgeMeshingProperty (prop.getNbEdges(), beta_resserrement, prop.getDirect())
-, m_beta(0.)
-, m_arm1(0.)
-, m_initWithArm1(false)
+EdgeMeshingPropertyBeta::EdgeMeshingPropertyBeta(const CoEdgeMeshingProperty &prop)
+    : CoEdgeMeshingProperty(prop.getNbEdges(), beta_resserrement, prop.getDirect())
+      , m_beta(0.)
+      , m_arm1(0.)
+      , m_initWithArm1(false)
 {
-	const EdgeMeshingPropertyBeta*	p = reinterpret_cast<const EdgeMeshingPropertyBeta*>(&prop);
-	if (0 == p)
-	{
-		TkUtil::UTF8String	messErr (TkUtil::Charset::UTF_8);
-        	messErr << "EdgeMeshingPropertyBeta, la propriété transmise en argument n'est pas de type EdgeMeshingPropertyBeta";
-	        throw TkUtil::Exception(messErr);
-	}	// if (0 == p)
+    const EdgeMeshingPropertyBeta *p = reinterpret_cast<const EdgeMeshingPropertyBeta *>(&prop);
+    if (nullptr == p)
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
+        messErr << "EdgeMeshingPropertyBeta, la propriété transmise en argument n'est pas de type EdgeMeshingPropertyBeta";
+        throw TkUtil::Exception(messErr);
+    }
 
-	m_beta			= p->m_beta;
-	m_arm1			= p->m_arm1;
-	m_initWithArm1	= p->m_initWithArm1;
+    m_beta = p->m_beta;
+    m_arm1 = p->m_arm1;
+    m_initWithArm1 = p->m_initWithArm1;
 }
+
 /*----------------------------------------------------------------------------*/
-bool EdgeMeshingPropertyBeta::operator == (const CoEdgeMeshingProperty& cedp) const
+bool EdgeMeshingPropertyBeta::operator ==(const CoEdgeMeshingProperty &cedp) const
 {
-	const EdgeMeshingPropertyBeta*	props	=
-					dynamic_cast<const EdgeMeshingPropertyBeta*> (&cedp);
-	if (0 == props)
-		return false;
+    const EdgeMeshingPropertyBeta *props =
+            dynamic_cast<const EdgeMeshingPropertyBeta *>(&cedp);
+    if (nullptr == props)
+    {
+        return false;
+    }
 
-	if (m_beta != props->m_beta)
-		return false;
+    if (m_beta != props->m_beta)
+    {
+        return false;
+    }
 
-	if (m_arm1 != props->m_arm1)
-		return false;
+    if (m_arm1 != props->m_arm1)
+    {
+        return false;
+    }
 
-	if (m_initWithArm1 != props->m_initWithArm1)
-		return false;
+    if (m_initWithArm1 != props->m_initWithArm1)
+    {
+        return false;
+    }
 
-	return CoEdgeMeshingProperty::operator == (cedp);
+    return CoEdgeMeshingProperty::operator ==(cedp);
 }
+
 /*----------------------------------------------------------------------------*/
 void EdgeMeshingPropertyBeta::setNbEdges(const int nb)
 {
     CoEdgeMeshingProperty::setNbEdges(nb);
 }
+
 /*----------------------------------------------------------------------------*/
 void EdgeMeshingPropertyBeta::initCoeff(double length)
 {
-	if (m_initWithArm1){
-		// on calcule le coefficient de resserement
-		m_beta = computeBeta(m_arm1);
-	}
-	initCoeff();
+    if (m_initWithArm1)
+    {
+        // on calcule le coefficient de resserement
+        m_beta = computeBeta(m_arm1);
+    }
+    initCoeff();
 }
 
+/*----------------------------------------------------------------------------*/
 void EdgeMeshingPropertyBeta::initCoeff()
 {
-#ifdef _DEBUG_beta
-	std::cout<<"EdgeMeshingPropertyBeta::initCoeff() "<<std::endl;
-#endif
-    if (m_beta==0.0){
-		TkUtil::UTF8String	messErr (TkUtil::Charset::UTF_8);
+    if (m_beta == 0.0)
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
         messErr << "Erreur interne: EdgeMeshingPropertyBeta, le coefficient de resserrement n'a pas été initialisé";
         throw TkUtil::Exception(messErr);
     }
@@ -107,132 +118,126 @@ void EdgeMeshingPropertyBeta::initCoeff()
     m_dernierIndice = 0;
 }
 
+/*----------------------------------------------------------------------------*/
 double EdgeMeshingPropertyBeta::
 nextCoeff()
 {
-    m_dernierIndice+=1;
+    m_dernierIndice += 1;
 
     double feta = 0.0;
     double eta = 0.0;
-    if (m_sens){
-    	eta = ((double)m_dernierIndice)/((double)m_nb_edges);
-    	feta=resserre(eta, m_beta);
+    if (m_sens)
+    {
+        eta = static_cast<double>(m_dernierIndice) / static_cast<double>(m_nb_edges);
+        feta = resserre(eta, m_beta);
     }
-    else {
-    	eta = ((double)m_nb_edges-m_dernierIndice)/((double)m_nb_edges);
-    	feta = 1.0-resserre(eta, m_beta);
+    else
+    {
+        eta = (static_cast<double>(m_nb_edges) - m_dernierIndice) / static_cast<double>(m_nb_edges);
+        feta = 1.0 - resserre(eta, m_beta);
     }
-
-#ifdef _DEBUG_beta
-	std::cout<<"EdgeMeshingPropertyBeta::nextCoeff (m_beta="<<m_beta<<") return "<<feta<<std::endl;
-#endif
 
     return feta;
 }
+
 /*----------------------------------------------------------------------------*/
-double EdgeMeshingPropertyBeta::resserre(double eta, double beta)
+double EdgeMeshingPropertyBeta::resserre(const double eta, const double beta)
 {
-	double p = std::log((beta + 1.0)/(beta - 1.0)) * (1.0 - eta);
-	return  1.0 + beta * (1.0 - std::exp(p)) / (1.0 + std::exp(p));
+    double p = std::log((beta + 1.0) / (beta - 1.0)) * (1.0 - eta);
+    return 1.0 + beta * (1.0 - std::exp(p)) / (1.0 + std::exp(p));
 }
+
 /*----------------------------------------------------------------------------*/
 TkUtil::UTF8String EdgeMeshingPropertyBeta::
 getScriptCommand() const
 {
-    TkUtil::UTF8String o (TkUtil::Charset::UTF_8);
-    o << getMgx3DAlias() << ".EdgeMeshingPropertyBeta("
-      << static_cast<long>(m_nb_edges) << ","
-      << Utils::Math::MgxNumeric::userRepresentation(m_beta);
+    TkUtil::UTF8String o(TkUtil::Charset::UTF_8);
+    o << getMgx3DAlias() << ".EdgeMeshingPropertyBeta( ";
+    o << static_cast<long>(m_nb_edges) << ", ";
+    o << Utils::Math::MgxNumeric::userRepresentation(m_beta);
+    o << (getDirect() ? std::string(", True") : std::string(", False"));
     if (m_initWithArm1)
     {
-        o << (getDirect() ? std::string(", True") : std::string(", False"));
         o << ", True"; // this is for m_initWithArm1
         o << ", " << Utils::Math::MgxNumeric::userRepresentation(m_arm1);
-    }
-    else if (!getDirect())
-    {
-        o << ", False";
     }
     o << ")";
     return o;
 }
+
 /*----------------------------------------------------------------------------*/
 void EdgeMeshingPropertyBeta::
-addDescription(Utils::SerializedRepresentation& topoProprietes) const
+addDescription(Utils::SerializedRepresentation &topoProprietes) const
 {
-	topoProprietes.addProperty (
-			Utils::SerializedRepresentation::Property ("Beta Resserrement", m_beta));
+    topoProprietes.addProperty(
+        Utils::SerializedRepresentation::Property("Beta Resserrement", m_beta));
 
-	if (getDirect())
-		topoProprietes.addProperty (
-				Utils::SerializedRepresentation::Property ("Sens", std::string("direct")));
-	else
-		topoProprietes.addProperty (
-				Utils::SerializedRepresentation::Property ("Sens", std::string("inverse")));
+    if (getDirect())
+    {
+        topoProprietes.addProperty(
+            Utils::SerializedRepresentation::Property("Sens", std::string("direct")));
+    }
+    else
+    {
+        topoProprietes.addProperty(
+            Utils::SerializedRepresentation::Property("Sens", std::string("inverse")));
+    }
 }
 
+/*----------------------------------------------------------------------------*/
 double EdgeMeshingPropertyBeta::
-computeBeta(const double lg)
+computeBeta(const double lg) const
 {
-#ifdef _DEBUG_beta
-	std::cout<<"EdgeMeshingPropertyBeta::computeBeta()"<<std::endl;
-#endif
+    // recherche de beta pour laquelle feta=m_arm1
+    double beta = 0.0;
+    const double eta = (1.0) / static_cast<double>(m_nb_edges);
 
-	// recherche de beta pour laquelle feta=m_arm1
-	double beta = 0.0;
-	double eta = 0.0;
-	if (m_sens){
-    	eta = (1.0)/((double)m_nb_edges);
-		std::cout << "eta = " << eta << std::endl;
+    // on limite la recherche
+    double beta1 = 1.00001;
+    double beta2 = 1.01;
+    const double lg1 = resserre(eta, beta1);
+    const double lg2 = resserre(eta, beta2);
+
+    if ((lg1 < lg && lg2 < lg) || (lg1 > lg && lg2 > lg))
+    {
+        TkUtil::UTF8String messErr(TkUtil::Charset::UTF_8);
+        messErr << "EdgeMeshingPropertyBeta, on ne peut pas trouver de beta pour lg ";
+        messErr << lg << " et nombre de bras de " << static_cast<short>(m_nb_edges);
+        throw TkUtil::Exception(messErr);
     }
-    else {
-    	eta = ((double)m_nb_edges-1.0)/((double)m_nb_edges);
-		std::cout << "eta = " << eta << std::endl;
-    }
+    uint iter = 0;
+    const bool sens = (lg1 < lg2);
+    while (!Utils::Math::MgxNumeric::isNearlyZero(beta2 - beta1) && iter < 100)
+    {
+        iter++;
+        beta = (beta1 + beta2) / 2.0;
+        const double lg_iter = resserre(eta, beta);
 
-	// on limite la recherche
-	double beta1 = 1.00001;
-	double beta2 = 1.01;
-	double lg1 = resserre(eta, beta1);
-	double lg2 = resserre(eta, beta2);
+        if (sens)
+        {
+            if (lg_iter > lg)
+            {
+                beta2 = beta;
+            }
+            else
+            {
+                beta1 = beta;
+            }
+        }
+        else
+        {
+            if (lg_iter < lg)
+            {
+                beta2 = beta;
+            }
+            else
+            {
+                beta1 = beta;
+            }
+        }
+    } // end while
 
-	std::cout << "lg1 = " << lg1 << ", lg2 = " << lg2 << ", lg = " << lg << std::endl;
-	if ((lg1<lg && lg2<lg) || (lg1>lg && lg2>lg)){
-		TkUtil::UTF8String	messErr (TkUtil::Charset::UTF_8);
-        messErr << "EdgeMeshingPropertyBeta, on ne peut pas trouver de beta pour lg "
-        		<<lg<<" et nombre de bras de "<<(short)m_nb_edges;
-	        throw TkUtil::Exception(messErr);
-	}
-	uint iter = 0;
-	bool sens = (lg1<lg2);
-	while (!Utils::Math::MgxNumeric::isNearlyZero(beta2-beta1) && iter < 100){
-		iter ++;
-		beta = (beta1+beta2)/2.0;
-
-		double lg_iter = resserre(eta, beta);
-#ifdef _DEBUG_beta
-		//std::cout<<"iter "<<iter<<std::endl;
-		//std::cout<<" beta "<<beta<<", lg_iter "<<lg_iter<<std::endl;
-#endif
-
-		if (sens){
-			if (lg_iter>lg)
-				beta2 = beta;
-			else
-				beta1 = beta;
-		}
-		else {
-			if (lg_iter<lg)
-				beta2 = beta;
-			else
-				beta1 = beta;
-		}
-	} // end while
-
-#ifdef _DEBUG_beta
-	std::cout<<"EdgeMeshingPropertyGeometric::computeBeta return "<<beta<<", iter "<<iter<<std::endl;
-#endif
-	return beta;
+    return beta;
 }
 
 /*----------------------------------------------------------------------------*/

--- a/src/Core/protected/Topo/EdgeMeshingPropertyBeta.h
+++ b/src/Core/protected/Topo/EdgeMeshingPropertyBeta.h
@@ -1,14 +1,4 @@
 /*----------------------------------------------------------------------------*/
-/*
- * \file EdgeMeshingPropertyBeta.h
- *
- *  \author Eric Brière de l'Isle
- *
- *  \date 21/1/2015
- *
- *  d'après ce qui a été fourni par Thierry Hocquellet et nommé "loi beta de resserrement sur paroi"
- */
-/*----------------------------------------------------------------------------*/
 #ifndef EDGEPROPERTYMESHINGBETA_H_
 #define EDGEPROPERTYMESHINGBETA_H_
 /*----------------------------------------------------------------------------*/
@@ -22,32 +12,37 @@ namespace Topo {
    @brief Propriété de la discrétisation d'une arête avec une discrétisation
    ayant un resserrement sur paroi
  */
-class EdgeMeshingPropertyBeta : public CoEdgeMeshingProperty {
+class EdgeMeshingPropertyBeta : public CoEdgeMeshingProperty
+{
 public:
 
     /*------------------------------------------------------------------------*/
-    /** Constructeur avec un nombre de bras spécifié,
+    /** @brief Constructeur avec un nombre de bras spécifié,
      *  la valeur de beta
      *  et la longueur du premier bras
-     *  \param beta coeff de resserrement , beta=1+epsilon  ; epsilon>  0;
+     *  @param nbBras nombre de bras
+     *  @param beta coeff de resserrement , beta=1+epsilon  ; epsilon>  0;
      *  en pratique beta peut varier de 1.01 (peu resséré) à 1.00001 (très resséré)
      *  Si la longueur du premier bras est non nulle, alors beta est calculé
+     *  @param isDirect sens de la discrétisation sur l'arête topo
+     *  @param initWithFirstEdge true si on impose la taille de première maille
+     *  @param meshingEdgeLength taille de la première maille imposée
      */
-    EdgeMeshingPropertyBeta(int nb, double beta, bool isDirect=true, bool initWithFirstEdge=false, double meshingEdgeLength=0.0);
+    EdgeMeshingPropertyBeta(int nbBras, double beta, bool isDirect=true, bool initWithFirstEdge=false, double meshingEdgeLength=0.0);
 
     /// Pour les pythoneries, cast par opérateur = :
-    EdgeMeshingPropertyBeta (const CoEdgeMeshingProperty&);
+    explicit EdgeMeshingPropertyBeta (const CoEdgeMeshingProperty&);
 
     /*------------------------------------------------------------------------*/
     /// Comparaison de 2 propriétés.
-    virtual bool operator == (const CoEdgeMeshingProperty&) const;
+    bool operator == (const CoEdgeMeshingProperty&) const override;
 
     /*------------------------------------------------------------------------*/
     /// Accesseur sur le nom de la méthode de maillage
-    virtual std::string getMeshLawName() const {return "Beta";}
+    std::string getMeshLawName() const override {return "Beta";}
 
     /// change le nombre de bras demandé pour un côté
-    virtual void setNbEdges(const int nb);
+    void setNbEdges(int nb) override;
 
     /// le ratio entre deux bras successifs
     double getBeta() const {return m_beta;}
@@ -58,28 +53,28 @@ public:
     double getFirstEdgeLength() const {return m_arm1;}
     void setFirstEdgeLength(const double & arm1) {m_arm1 = arm1;}
 
-    #ifndef SWIG
+#ifndef SWIG
     /** Création d'un clone, on copie toutes les informations */
-    virtual CoEdgeMeshingProperty* clone() {return new  EdgeMeshingPropertyBeta(*this);}
+    CoEdgeMeshingProperty* clone() override {return new  EdgeMeshingPropertyBeta(*this);}
 
-    // initialisation avant appel à nextCoeff
-    virtual void initCoeff();
+    /// initialisation avant appel à nextCoeff
+    void initCoeff() override;
 
     /// initialisation avant appel à nextCoeff pour le cas où la longueur est utile
-    virtual void initCoeff(double length);
+    void initCoeff(double length) override;
 
     /// retourne le coefficient suivant pour les noeuds internes
-    virtual double nextCoeff();
+    double nextCoeff() override;
 
     /*------------------------------------------------------------------------*/
     /// Script pour la commande de création Python
-    virtual TkUtil::UTF8String getScriptCommand() const;
+    TkUtil::UTF8String getScriptCommand() const override;
 
     /*------------------------------------------------------------------------*/
     /** Ajoute les informations spécifiques de cette discrétisation à
      *  la représentation textuelle
      */
-    virtual void addDescription(Utils::SerializedRepresentation& topoProprietes) const;
+    void addDescription(Utils::SerializedRepresentation& topoProprietes) const override;
 
 #endif
 
@@ -89,10 +84,10 @@ private:
      feta=1-->  frontière amont)
      transformation de (0,1) sur (0,1) permettant de resserrer le maillage au voisinage du corps
      */
-    double resserre(double eta, double beta);
+    static double resserre(double eta, double beta);
 
     /// calcul de beta
-    double computeBeta(const double lg);
+    double computeBeta(double lg) const;
 
     /// valeur de beta pour le resserrement (de la forme 1+epsilon)
     double m_beta;

--- a/test_link/test_law_beta.py
+++ b/test_link/test_law_beta.py
@@ -21,6 +21,9 @@ def test_law_beta(capfd):
     # Changement de discrétisation pour les arêtes Ar0000
     emp = Mgx3D.EdgeMeshingPropertyBeta(10, 1.1, True, True, s1_ar0000)
     ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
+    # Changement de discrétisation pour les arêtes Ar0001
+    emp = Mgx3D.EdgeMeshingPropertyBeta(10, 1.1, False, True, s1_ar0000)
+    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0001"])
     # Création du maillage pour tous les blocs
     ctx.getMeshManager().newAllBlocksMesh()
 
@@ -33,10 +36,15 @@ def test_law_beta(capfd):
     # we choose a tolerance for tests on sizes
     eps = 10e-9
 
-    # test of first mesh edge size of topo edge Ar00000
+    # test of first mesh edge size of topo edge Ar0000
     n0 = mesh_lima.noeud(0)
     n8 = mesh_lima.noeud(8)
     assert( abs(l2_norme(n0, n8) - s1_ar0000) < eps )
+
+    # test of first mesh edge size of topo edge Ar0001
+    n2 = mesh_lima.noeud(2)
+    n25 = mesh_lima.noeud(25)
+    assert( abs(l2_norme(n2, n25) - s1_ar0000) < eps )
 
 
 
@@ -73,7 +81,7 @@ def test_law_beta_onCurve_1(capfd):
     # we choose a tolerance for tests on sizes
     eps = 10e-9
 
-    # test of first mesh edge size of topo edge Ar00000
+    # test of first mesh edge size of topo edge Ar0000
     n0 = mesh_lima.noeud(0)
     n8 = mesh_lima.noeud(8)
     # target meshing edge size (not respected)
@@ -131,35 +139,10 @@ def test_law_beta_onCurve_2(capfd):
     # we choose a tolerance for tests on sizes
     eps = 10e-9
 
-    # test of first mesh edge size of topo edge Ar00001
+    # test of first mesh edge size of topo edge Ar0001
     n2  = mesh_lima.noeud(2)
     n17 = mesh_lima.noeud(17)
     # target meshing edge size (not respected)
     assert( abs(l2_norme(n2, n17) - s1_ar0001) > eps )
     # real meshing edge size
     assert( abs(l2_norme(n2, n17) - 0.0000594519721850694) < eps )
-
-
-
-# This test case shows that the "Inverser le sens" option doesn't work when the
-# beta law is used with a target first mesh edge size. To show this, we use the
-# same test as "test_law_beta", which is successful, and the only
-# difference is we turn false the direction option.
-def test_law_beta_fail(capfd):
-    ctx = Mgx3D.getStdContext()
-    ctx.clearSession() # Clean the session after the previous test
-
-    # chosen first mesh edge size
-    s1_ar0000 = 0.005
-
-    # Création d'une boite avec une topologie
-    ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
-
-    # Changement de discrétisation pour les arêtes Ar0000
-    emp = Mgx3D.EdgeMeshingPropertyBeta(10, 1.1, False, True, s1_ar0000)
-    ctx.getTopoManager().setMeshingProperty (emp, ["Ar0000"])
-    with pytest.raises(RuntimeError) as excinfo:
-        # Création du maillage pour tous les blocs
-        ctx.getMeshManager().newAllBlocksMesh()
-    expected = "EdgeMeshingPropertyBeta, on ne peut pas trouver de beta"
-    assert expected in str(excinfo.value)


### PR DESCRIPTION
# Problem statement

This python script pass:

```
# Création d'une boite avec une topologie
ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
# Changement de discrétisation pour les arêtes Ar0006 (dans le sens direct, la discretization se passe bien)
emp = Mgx3D.EdgeMeshingPropertyBeta(10,1.01, True, True, 0.005)
ctx.getTopoManager().setMeshingProperty (emp, ["Ar0006"])
# Création du maillage pour tous les blocs
ctx.getMeshManager().newAllBlocksMesh()
```

While this one returns an error:

```
# Création d'une boite avec une topologie
ctx.getTopoManager().newBoxWithTopo (Mgx3D.Point(0, 0, 0), Mgx3D.Point(1, 1, 1), 10, 10, 10)
# Changement de discrétisation pour les arêtes Ar0006 (ici, dans le sens indirect, ça lance un message d'erreur)
emp = Mgx3D.EdgeMeshingPropertyBeta(10,1.01, False, True, 0.005)
ctx.getTopoManager().setMeshingProperty (emp, ["Ar0006"])
# Création du maillage pour tous les blocs
ctx.getMeshManager().newAllBlocksMesh()
```

The only difference between the two is the direction in which the beta law is imposed on the topological edge. This should not be a problem, since the sizes (size of the topological edge, size of the first imposed mesh edge, and number of meshing edges of the topological edge) are the same.
I have not found any value for which the mesh of the topological edge with the beta function works when selecting the "Invert the meaning" option.

This issue was highlighted in a python test, in _test_law_beta.py_.

# Proposed solution

To fix this issue, we propose that the beta computation no longer depends on the direction, but only on the three parameters:
    * the size of the topological edge;
    * the size of the first imposed mesh edge;
    * and the number of meshing edges of the topological edge.
The direction is only taken into account for the _coefficients_ computation, once the beta parameter is computed.
 
The python test is updated accordingly to this fix.